### PR TITLE
Allowing users to reference google protobuf common types, specifially "Any"

### DIFF
--- a/fixtures/semantic_api-options.proto
+++ b/fixtures/semantic_api-options.proto
@@ -4,11 +4,11 @@ import "google/protobuf/wrappers.proto";
 
 import "google/protobuf/empty.proto";
 
-import "google/protobuf/any.proto";
-
 import "google/api/annotations.proto";
 
 import "blah/thing.proto";
+
+import "google/protobuf/any.proto";
 
 import "something.proto";
 
@@ -178,19 +178,20 @@ message TestModel {
         string something = 1;
     }
     repeated Class class = 2;
-    google.protobuf.Any test_any_value = 3;
-    bool test_bool = 4;
-    google.protobuf.BoolValue test_bool_value = 5;
-    google.protobuf.BytesValue test_bytes_value = 6;
-    blah.Thing test_external_ref = 7;
-    google.protobuf.Any test_float_value = 8;
-    map<string, TestModel> test_map_object = 9;
-    map<string, string> test_map_scalar = 10;
-    google.protobuf.DoubleValue test_num_value = 11;
-    google.protobuf.Int32Value test_numer_value = 12;
-    something.RelativeBackRef test_relative_backdir_ref = 13;
-    something.RelativeRef test_relative_ref = 14;
-    google.protobuf.StringValue test_string_value = 15;
+    google.protobuf.Any test_any_ref = 3;
+    google.protobuf.Any test_any_value = 4;
+    bool test_bool = 5;
+    google.protobuf.BoolValue test_bool_value = 6;
+    google.protobuf.BytesValue test_bytes_value = 7;
+    blah.Thing test_external_ref = 8;
+    google.protobuf.Any test_float_value = 9;
+    map<string, TestModel> test_map_object = 10;
+    map<string, string> test_map_scalar = 11;
+    google.protobuf.DoubleValue test_num_value = 12;
+    google.protobuf.Int32Value test_numer_value = 13;
+    something.RelativeBackRef test_relative_backdir_ref = 14;
+    something.RelativeRef test_relative_ref = 15;
+    google.protobuf.StringValue test_string_value = 16;
 }
 
 service TheSemanticAPIService {

--- a/fixtures/semantic_api.json
+++ b/fixtures/semantic_api.json
@@ -521,6 +521,9 @@
         },
         "test_external_ref": {
             "$ref": "http://blah.com/blah/thing.json"
+        },
+        "test_any_ref": {
+            "$ref": "google/protobuf/any.proto"
         }
      }
     }

--- a/fixtures/semantic_api.proto
+++ b/fixtures/semantic_api.proto
@@ -4,9 +4,9 @@ import "google/protobuf/wrappers.proto";
 
 import "google/protobuf/empty.proto";
 
-import "google/protobuf/any.proto";
-
 import "blah/thing.proto";
+
+import "google/protobuf/any.proto";
 
 import "something.proto";
 
@@ -176,19 +176,20 @@ message TestModel {
         string something = 1;
     }
     repeated Class class = 2;
-    google.protobuf.Any test_any_value = 3;
-    bool test_bool = 4;
-    google.protobuf.BoolValue test_bool_value = 5;
-    google.protobuf.BytesValue test_bytes_value = 6;
-    blah.Thing test_external_ref = 7;
-    google.protobuf.Any test_float_value = 8;
-    map<string, TestModel> test_map_object = 9;
-    map<string, string> test_map_scalar = 10;
-    google.protobuf.DoubleValue test_num_value = 11;
-    google.protobuf.Int32Value test_numer_value = 12;
-    something.RelativeBackRef test_relative_backdir_ref = 13;
-    something.RelativeRef test_relative_ref = 14;
-    google.protobuf.StringValue test_string_value = 15;
+    google.protobuf.Any test_any_ref = 3;
+    google.protobuf.Any test_any_value = 4;
+    bool test_bool = 5;
+    google.protobuf.BoolValue test_bool_value = 6;
+    google.protobuf.BytesValue test_bytes_value = 7;
+    blah.Thing test_external_ref = 8;
+    google.protobuf.Any test_float_value = 9;
+    map<string, TestModel> test_map_object = 10;
+    map<string, string> test_map_scalar = 11;
+    google.protobuf.DoubleValue test_num_value = 12;
+    google.protobuf.Int32Value test_numer_value = 13;
+    something.RelativeBackRef test_relative_backdir_ref = 14;
+    something.RelativeRef test_relative_ref = 15;
+    google.protobuf.StringValue test_string_value = 16;
 }
 
 service TheSemanticAPIService {

--- a/openapi.go
+++ b/openapi.go
@@ -132,6 +132,7 @@ func refType(ref string, defs map[string]*Items) (string, string) {
 
 	if rawPkg != "" ||
 		strings.HasSuffix(ref, ".json") ||
+		strings.HasSuffix(ref, ".proto") ||
 		strings.HasSuffix(ref, ".yaml") {
 		if rawPkg == "" {
 			rawPkg = ref

--- a/proto.go
+++ b/proto.go
@@ -184,19 +184,22 @@ func cleanSpacing(output []byte) []byte {
 }
 
 func addImports(output []byte) []byte {
-	if bytes.Contains(output, []byte("google.protobuf.Any")) {
+	if bytes.Contains(output, []byte("google.protobuf.Any")) &&
+		!bytes.Contains(output, []byte("import \"google/protobuf/any.proto")) {
 		output = bytes.Replace(output, []byte(`"proto3";`), []byte(`"proto3";
 
 import "google/protobuf/any.proto";`), 1)
 	}
 
-	if bytes.Contains(output, []byte("google.protobuf.Empty")) {
+	if bytes.Contains(output, []byte("google.protobuf.Empty")) &&
+		!bytes.Contains(output, []byte("import \"google/protobuf/empty.proto")) {
 		output = bytes.Replace(output, []byte(`"proto3";`), []byte(`"proto3";
 
 import "google/protobuf/empty.proto";`), 1)
 	}
 
-	if bytes.Contains(output, []byte("google.protobuf.NullValue")) {
+	if bytes.Contains(output, []byte("google.protobuf.NullValue")) &&
+		!bytes.Contains(output, []byte("import \"google/protobuf/struct.proto")) {
 		output = bytes.Replace(output, []byte(`"proto3";`), []byte(`"proto3";
 
 import "google/protobuf/struct.proto";`), 1)
@@ -206,7 +209,8 @@ import "google/protobuf/struct.proto";`), 1)
 	if err != nil {
 		log.Fatal("unable to find wrapper values: ", err)
 	}
-	if match {
+	if match &&
+		!bytes.Contains(output, []byte("import \"google/protobuf/wrappers.proto")) {
 		output = bytes.Replace(output, []byte(`"proto3";`), []byte(`"proto3";
 
 import "google/protobuf/wrappers.proto";`), 1)


### PR DESCRIPTION
Leaning on the new ability to reference external resources, this PR makes it possible to reference common google/protobuf types without worrying about double imports.
