### PR TITLE
Use new `x-proto-tag` Open API extension to set the Protobuf tag of message fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ There are 2 CLI flags for using the tool:
 * Endpoints that respond with an array will be wrapped with a message type that has a single field, 'items', that contains the array.
 * Only "200" and "201" responses are inspected for determining the expected return value for RPC endpoints.
 * To prevent enum collisions and to match the [protobuf style guide](https://developers.google.com/protocol-buffers/docs/style#enums), enum values will be `CAPITALS_WITH_UNDERSCORES` and nested enum values and will have their parent types prepended.
+* To allow for more control over how your protobuf schema evolves, all parameters and property definitions will accept an optional extension parameter, `x-proto-tag`, that will overide the generated tag with the value supplied.
 
 ## Example
 ```

--- a/fixtures/semantic_api-options.proto
+++ b/fixtures/semantic_api-options.proto
@@ -178,19 +178,19 @@ message TestModel {
         string something = 1;
     }
     repeated Class class = 2;
-    google.protobuf.Any test_any_value = 3;
-    bool test_bool = 4;
-    google.protobuf.BoolValue test_bool_value = 5;
-    google.protobuf.BytesValue test_bytes_value = 6;
-    blah.Thing test_external_ref = 7;
-    google.protobuf.Any test_float_value = 8;
-    map<string, TestModel> test_map_object = 9;
-    map<string, string> test_map_scalar = 10;
-    google.protobuf.DoubleValue test_num_value = 11;
-    google.protobuf.Int32Value test_numer_value = 12;
-    something.RelativeBackRef test_relative_backdir_ref = 13;
-    something.RelativeRef test_relative_ref = 14;
-    google.protobuf.StringValue test_string_value = 15;
+    google.protobuf.Any test_any_value = 10;
+    bool test_bool = 3;
+    google.protobuf.BoolValue test_bool_value = 4;
+    google.protobuf.BytesValue test_bytes_value = 9;
+    blah.Thing test_external_ref = 15;
+    google.protobuf.Any test_float_value = 7;
+    map<string, TestModel> test_map_object = 11;
+    map<string, string> test_map_scalar = 12;
+    google.protobuf.DoubleValue test_num_value = 5;
+    google.protobuf.Int32Value test_numer_value = 6;
+    something.RelativeBackRef test_relative_backdir_ref = 14;
+    something.RelativeRef test_relative_ref = 13;
+    google.protobuf.StringValue test_string_value = 8;
 }
 
 service TheSemanticAPIService {

--- a/fixtures/semantic_api.json
+++ b/fixtures/semantic_api.json
@@ -445,88 +445,103 @@
 			  "nytd_per",
 			  "nytd_org",
 			  "nytd_des"
-			]
+            ]
         }
       }
     },
     "TestStringRef": {
-      "type": "string",
-      "minLength": 3
+        "type": "string",
+        "minLength": 3
     },
     "TestModel": {
-      "type": "object",
-      "properties": {
-        "category": {
-			"type": "string",
-			"enum": [
-			  "nytd_geo",
-			  "nytd_per",
-			  "nytd_org",
-			  "nytd_des"
-			]
-        },
-		"class": {
-			"type": "array",
-			"items": {
-			"type":"object",
-			  "properties": {
-				"something": {
-					"type": "string"
-				}
-			  }
-			}
-        },
-		"test_bool": {
-			"type": "boolean"
-        },
-        "test_bool_value": {
-			"type": ["null", "boolean"]
-        },
-        "test_num_value": {
-			"type": ["null", "number"],
-            "format": "double"
-        },
-        "test_numer_value": {
-			"type": ["null", "number"]
-        },
-        "test_float_value": {
-			"type": ["null", "float"]
-        },
-        "test_string_value": {
-			"type": ["null", "string"]
-        },
-        "test_bytes_value": {
-			"type": ["null", "bytes"]
-        },
-        "test_any_value": {
-			"type": ["null", "string", "object"]
-        },
-        "test_map_object": {
-            "type": "object",
-            "additionalProperties": {
-                "$ref": "#/definitions/TestModel"
+        "type": "object",
+        "properties": {
+            "category": {
+                "type": "string",
+                "enum": [
+                    "nytd_geo",
+                    "nytd_per",
+                    "nytd_org",
+                    "nytd_des"
+                ],
+                "x-proto-tag": 1
+            },
+            "class": {
+                "type": "array",
+                "items": {
+                    "type":"object",
+                    "properties": {
+                        "something": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "x-proto-tag": 2
+            },
+            "test_bool": {
+                "type": "boolean",
+                "x-proto-tag": 3
+            },
+            "test_bool_value": {
+                "type": ["null", "boolean"],
+                "x-proto-tag": 4
+            },
+            "test_num_value": {
+                "type": ["null", "number"],
+                "format": "double",
+                "x-proto-tag": 5
+            },
+            "test_numer_value": {
+                "type": ["null", "number"],
+                "x-proto-tag": 6
+            },
+            "test_float_value": {
+                "type": ["null", "float"],
+                "x-proto-tag": 7
+            },
+            "test_string_value": {
+                "type": ["null", "string"],
+                "x-proto-tag": 8
+            },
+            "test_bytes_value": {
+                "type": ["null", "bytes"],
+                "x-proto-tag": 9
+            },
+            "test_any_value": {
+                "type": ["null", "string", "object"],
+                "x-proto-tag": 10
+            },
+            "test_map_object": {
+                "type": "object",
+                "additionalProperties": {
+                    "$ref": "#/definitions/TestModel"
+                },
+                "x-proto-tag": 11
+            },
+            "test_map_scalar": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "string"
+                },
+                "x-proto-tag": 12
+            },
+            "test_relative_ref": {
+                "$ref": "something.json#/definitions/RelativeRef",
+                "x-proto-tag": 13
+            },
+            "test_relative_backdir_ref": {
+                "$ref": "../something.json#/definitions/RelativeBackRef",
+                "x-proto-tag": 14
+            },
+            "test_external_ref": {
+                "$ref": "http://blah.com/blah/thing.json",
+                "x-proto-tag": 15
             }
-        },
-        "test_map_scalar": {
-            "type": "object",
-            "additionalProperties": {
-                "type": "string"
-            }
-        },
-        "test_relative_ref": {
-            "$ref": "something.json#/definitions/RelativeRef"
-        },
-        "test_relative_backdir_ref": {
-            "$ref": "../something.json#/definitions/RelativeBackRef"
-        },
-        "test_external_ref": {
-            "$ref": "http://blah.com/blah/thing.json"
         }
-     }
     }
   },
   "securityDefinitions": {
-    "apikey": {
+      "apikey": {
       "type": "apiKey",
       "name": "api-key",
       "in": "query"

--- a/fixtures/semantic_api.proto
+++ b/fixtures/semantic_api.proto
@@ -176,19 +176,19 @@ message TestModel {
         string something = 1;
     }
     repeated Class class = 2;
-    google.protobuf.Any test_any_value = 3;
-    bool test_bool = 4;
-    google.protobuf.BoolValue test_bool_value = 5;
-    google.protobuf.BytesValue test_bytes_value = 6;
-    blah.Thing test_external_ref = 7;
-    google.protobuf.Any test_float_value = 8;
-    map<string, TestModel> test_map_object = 9;
-    map<string, string> test_map_scalar = 10;
-    google.protobuf.DoubleValue test_num_value = 11;
-    google.protobuf.Int32Value test_numer_value = 12;
-    something.RelativeBackRef test_relative_backdir_ref = 13;
-    something.RelativeRef test_relative_ref = 14;
-    google.protobuf.StringValue test_string_value = 15;
+    google.protobuf.Any test_any_value = 10;
+    bool test_bool = 3;
+    google.protobuf.BoolValue test_bool_value = 4;
+    google.protobuf.BytesValue test_bytes_value = 9;
+    blah.Thing test_external_ref = 15;
+    google.protobuf.Any test_float_value = 7;
+    map<string, TestModel> test_map_object = 11;
+    map<string, string> test_map_scalar = 12;
+    google.protobuf.DoubleValue test_num_value = 5;
+    google.protobuf.Int32Value test_numer_value = 6;
+    something.RelativeBackRef test_relative_backdir_ref = 14;
+    something.RelativeRef test_relative_ref = 13;
+    google.protobuf.StringValue test_string_value = 8;
 }
 
 service TheSemanticAPIService {

--- a/openapi.go
+++ b/openapi.go
@@ -70,6 +70,8 @@ type Items struct {
 	Format interface{} `yaml:"format,omitempty" json:"format,omitempty"`
 	Enum   []string    `yaml:"enum,omitempty" json:"enum,omitempty"`
 
+	ProtoTag int `yaml:"x-proto-tag" json:"x-proto-tag"`
+
 	// Map type
 	AdditionalProperties *Items `yaml:"additionalProperties" json:"additionalProperties"`
 
@@ -186,6 +188,9 @@ func refDef(name, ref string, index int, defs map[string]*Items) string {
 // current Items and information.
 func (i *Items) ProtoMessage(msgName, name string, defs map[string]*Items, indx *int, depth int) string {
 	*indx++
+	if i.ProtoTag != 0 {
+		*indx = i.ProtoTag
+	}
 	index := *indx
 	name = strings.Replace(name, "-", "_", -1)
 

--- a/proto_test.go
+++ b/proto_test.go
@@ -207,7 +207,7 @@ func TestGenerateProto(t *testing.T) {
 		}
 
 		if string(want) != string(protoResult) {
-			t.Errorf("testYaml expected:\n%s\nGOT:\n%s", want, protoResult)
+			t.Errorf("testYaml expected:\n%q\nGOT:\n%q", want, protoResult)
 		}
 	}
 }


### PR DESCRIPTION
This PR introduces a new field, `x-proto-tag`, that can be included on any object property or request parameter to set the Protobuf tag value.

One future improvement that can be made would be to order message attributes by the new Protobuf tag instead of alphabetically.