### PR TITLE
Passing comments from the Open API spec to the Protobuf spec

### DIFF
--- a/fixtures/books-options.proto
+++ b/fixtures/books-options.proto
@@ -7,24 +7,40 @@ import "google/api/annotations.proto";
 package booksapi;
 
 message GetListsformatRequest {
+    // YYYY-MM-DD
+    // 
+    // The week-ending date for the sales reflected on list-name. Times best-seller lists are compiled using available book sale data. The bestsellers-date may be significantly earlier than published-date. For additional information, see the explanation at the bottom of any best-seller list page on NYTimes.com (example: Hardcover Fiction, published Dec. 5 but reflecting sales to Nov. 29).
     string bestsellers_date = 1;
+    // YYYY-MM-DD  The date the best-seller list was published on NYTimes.com (compare bestsellers-date)
     string date = 2;
     enum GetListsformatRequest_Format {
         GETLISTSFORMATREQUEST_FORMAT_JSON = 0;
         GETLISTSFORMATREQUEST_FORMAT_JSONP = 1;
     }
     GetListsformatRequest_Format format = 3;
+    // International Standard Book Number, 10 or 13 digits
     string isbn = 4;
+    // The name of the Times best-seller list. To get valid values, use a list names request.
+    // 
+    // Be sure to replace spaces with hyphens (e.g., e-book-fiction or hardcover-fiction, not E-Book Fiction or Hardcover Fiction). (The parameter is not case sensitive.)
     string list = 5;
+    // Sets the starting point of the result set
     int32 offset = 6;
+    // YYYY-MM-DD
+    // 
+    // The date the best-seller list was published on NYTimes.com (compare bestsellers-date)
     string published_date = 7;
+    // The rank of the best seller on list-name as of bestsellers-date
     int32 rank = 8;
+    // The rank of the best seller on list-name one week prior to bestsellers-date
     int32 rank_last_week = 9;
+    // Sets the sort order of the result set
     enum GetListsformatRequest_Sort_order {
         GETLISTSFORMATREQUEST_SORT_ORDER_ASC = 0;
         GETLISTSFORMATREQUEST_SORT_ORDER_DESC = 1;
     }
     GetListsformatRequest_Sort_order sort_order = 10;
+    // The number of weeks that the best seller has been on list-name, as of bestsellers-date
     int32 weeks_on_list = 11;
 }
 
@@ -74,12 +90,31 @@ message GetListsformatResponse {
 }
 
 message GetListsBestSellersHistoryRequest {
+    // The target age group for the best seller.
     string age_group = 1;
+    // The author of the best seller. The author field does not include additional contributors (see Data Structure for more details about the author and contributor fields).
+    // 
+    // When searching the author field, you can specify any combination of first, middle and last names.
+    // 
+    // When sort-by is set to author, the results will be sorted by author's first name.
     string author = 2;
+    // The author of the best seller, as well as other contributors such as the illustrator (to search or sort by author name only, use author instead).
+    // 
+    // When searching, you can specify any combination of first, middle and last names of any of the contributors.
+    // 
+    // When sort-by is set to contributor, the results will be sorted by the first name of the first contributor listed.
     string contributor = 3;
+    // International Standard Book Number, 10 or 13 digits
+    // 
+    // A best seller may have both 10-digit and 13-digit ISBNs, and may have multiple ISBNs of each type. To search on multiple ISBNs, separate the ISBNs with semicolons (example: 9780446579933;0061374229).
     string isbn = 4;
+    // The publisher's list price of the best seller, including decimal point
     string price = 5;
+    // The standardized name of the publisher
     string publisher = 6;
+    // The title of the best seller
+    // 
+    // When searching, you can specify a portion of a title or a full title.
     string title = 7;
 }
 
@@ -157,6 +192,11 @@ message GetListsOverviewformatRequest {
         GETLISTSOVERVIEWFORMATREQUEST_FORMAT_JSONP = 1;
     }
     GetListsOverviewformatRequest_Format format = 2;
+    // The best-seller list publication date. YYYY-MM-DD
+    // 
+    // You do not have to specify the exact date the list was published. The service will search forward (into the future) for the closest publication date to the date you specify. For example, a request for lists/overview/2013-05-22 will retrieve the list that was published on 05-26.
+    // 
+    // If you do not include a published_date, the current week's best-sellers lists will be returned.
     string published_date = 3;
 }
 
@@ -196,20 +236,36 @@ message GetListsOverviewformatResponse {
 }
 
 message GetListsDateListRequest {
+    // YYYY-MM-DD
+    // 
+    // The week-ending date for the sales reflected on list-name. Times best-seller lists are compiled using available book sale data. The bestsellers-date may be significantly earlier than published-date. For additional information, see the explanation at the bottom of any best-seller list page on NYTimes.com (example: Hardcover Fiction, published Dec. 5 but reflecting sales to Nov. 29).
     string bestsellers_date = 1;
     string date = 2;
+    // International Standard Book Number, 10 or 13 digits
     int32 isbn = 3;
+    // Name of the Best Sellers List. You can get the full list from /lists/names.json
     string list = 4;
+    // The name of the Times best-seller list. To get valid values, use a list names request.
+    // 
+    // Be sure to replace spaces with hyphens (e.g., e-book-fiction or hardcover-fiction, not E-Book Fiction or Hardcover Fiction). (The parameter is not case sensitive.)
     string list_name = 5;
+    // Sets the starting point of the result set
     int32 offset = 6;
+    // YYYY-MM-DD
+    // 
+    // The date the best-seller list was published on NYTimes.com (compare bestsellers-date)
     string published_date = 7;
+    // The rank of the best seller on list-name as of bestsellers-date
     string rank = 8;
+    // The rank of the best seller on list-name one week prior to bestsellers-date
     int32 rank_last_week = 9;
+    // The default is ASC (ascending). The sort-order parameter is used with the sort-by parameter — for details, see each request type.
     enum GetListsDateListRequest_Sort_order {
         GETLISTSDATELISTREQUEST_SORT_ORDER_ASC = 0;
         GETLISTSDATELISTREQUEST_SORT_ORDER_DESC = 1;
     }
     GetListsDateListRequest_Sort_order sort_order = 10;
+    // The number of weeks that the best seller has been on list-name, as of bestsellers-date
     int32 weeks_on_list = 11;
 }
 
@@ -263,13 +319,16 @@ message GetListsDateListResponse {
 
 message GetReviewsformatRequest {
     string api_key = 1;
+    // You’ll need to enter the author’s first and last name, separated by a space. This space will be converted into the characters %20.
     string author = 2;
     enum GetReviewsformatRequest_Format {
         GETREVIEWSFORMATREQUEST_FORMAT_JSON = 0;
         GETREVIEWSFORMATREQUEST_FORMAT_JSONP = 1;
     }
     GetReviewsformatRequest_Format format = 3;
+    // Searching by ISBN is the recommended method. You can enter 10- or 13-digit ISBNs.
     int32 isbn = 4;
+    // You’ll need to enter the full title of the book. Spaces in the title will be converted into the characters %20.
     string title = 5;
 }
 
@@ -290,31 +349,37 @@ message GetReviewsformatResponse {
 }
 
 service BooksAPIService {
+    // Best Seller List
     rpc GetListsformat(GetListsformatRequest) returns (GetListsformatResponse) {
       option (google.api.http) = {
         get: "/svc/books/v3/lists.{format}"
       };
     }
+    // Best Seller History List
     rpc GetListsBestSellersHistory(GetListsBestSellersHistoryRequest) returns (GetListsBestSellersHistoryResponse) {
       option (google.api.http) = {
         get: "/svc/books/v3/lists/best-sellers/history.json"
       };
     }
+    // Best Seller List Names
     rpc GetListsNamesformat(GetListsNamesformatRequest) returns (GetListsNamesformatResponse) {
       option (google.api.http) = {
         get: "/svc/books/v3/lists/names.{format}"
       };
     }
+    // Best Seller List Overview
     rpc GetListsOverviewformat(GetListsOverviewformatRequest) returns (GetListsOverviewformatResponse) {
       option (google.api.http) = {
         get: "/svc/books/v3/lists/overview.{format}"
       };
     }
+    // Best Seller List by Date
     rpc GetListsDateList(GetListsDateListRequest) returns (GetListsDateListResponse) {
       option (google.api.http) = {
         get: "/svc/books/v3/lists/{date}/{list}.json"
       };
     }
+    // Reviews
     rpc GetReviewsformat(GetReviewsformatRequest) returns (GetReviewsformatResponse) {
       option (google.api.http) = {
         get: "/svc/books/v3/reviews.{format}"

--- a/fixtures/books.proto
+++ b/fixtures/books.proto
@@ -5,24 +5,40 @@ import "google/protobuf/struct.proto";
 package booksapi;
 
 message GetListsformatRequest {
+    // YYYY-MM-DD
+    // 
+    // The week-ending date for the sales reflected on list-name. Times best-seller lists are compiled using available book sale data. The bestsellers-date may be significantly earlier than published-date. For additional information, see the explanation at the bottom of any best-seller list page on NYTimes.com (example: Hardcover Fiction, published Dec. 5 but reflecting sales to Nov. 29).
     string bestsellers_date = 1;
+    // YYYY-MM-DD  The date the best-seller list was published on NYTimes.com (compare bestsellers-date)
     string date = 2;
     enum GetListsformatRequest_Format {
         GETLISTSFORMATREQUEST_FORMAT_JSON = 0;
         GETLISTSFORMATREQUEST_FORMAT_JSONP = 1;
     }
     GetListsformatRequest_Format format = 3;
+    // International Standard Book Number, 10 or 13 digits
     string isbn = 4;
+    // The name of the Times best-seller list. To get valid values, use a list names request.
+    // 
+    // Be sure to replace spaces with hyphens (e.g., e-book-fiction or hardcover-fiction, not E-Book Fiction or Hardcover Fiction). (The parameter is not case sensitive.)
     string list = 5;
+    // Sets the starting point of the result set
     int32 offset = 6;
+    // YYYY-MM-DD
+    // 
+    // The date the best-seller list was published on NYTimes.com (compare bestsellers-date)
     string published_date = 7;
+    // The rank of the best seller on list-name as of bestsellers-date
     int32 rank = 8;
+    // The rank of the best seller on list-name one week prior to bestsellers-date
     int32 rank_last_week = 9;
+    // Sets the sort order of the result set
     enum GetListsformatRequest_Sort_order {
         GETLISTSFORMATREQUEST_SORT_ORDER_ASC = 0;
         GETLISTSFORMATREQUEST_SORT_ORDER_DESC = 1;
     }
     GetListsformatRequest_Sort_order sort_order = 10;
+    // The number of weeks that the best seller has been on list-name, as of bestsellers-date
     int32 weeks_on_list = 11;
 }
 
@@ -72,12 +88,31 @@ message GetListsformatResponse {
 }
 
 message GetListsBestSellersHistoryRequest {
+    // The target age group for the best seller.
     string age_group = 1;
+    // The author of the best seller. The author field does not include additional contributors (see Data Structure for more details about the author and contributor fields).
+    // 
+    // When searching the author field, you can specify any combination of first, middle and last names.
+    // 
+    // When sort-by is set to author, the results will be sorted by author's first name.
     string author = 2;
+    // The author of the best seller, as well as other contributors such as the illustrator (to search or sort by author name only, use author instead).
+    // 
+    // When searching, you can specify any combination of first, middle and last names of any of the contributors.
+    // 
+    // When sort-by is set to contributor, the results will be sorted by the first name of the first contributor listed.
     string contributor = 3;
+    // International Standard Book Number, 10 or 13 digits
+    // 
+    // A best seller may have both 10-digit and 13-digit ISBNs, and may have multiple ISBNs of each type. To search on multiple ISBNs, separate the ISBNs with semicolons (example: 9780446579933;0061374229).
     string isbn = 4;
+    // The publisher's list price of the best seller, including decimal point
     string price = 5;
+    // The standardized name of the publisher
     string publisher = 6;
+    // The title of the best seller
+    // 
+    // When searching, you can specify a portion of a title or a full title.
     string title = 7;
 }
 
@@ -155,6 +190,11 @@ message GetListsOverviewformatRequest {
         GETLISTSOVERVIEWFORMATREQUEST_FORMAT_JSONP = 1;
     }
     GetListsOverviewformatRequest_Format format = 2;
+    // The best-seller list publication date. YYYY-MM-DD
+    // 
+    // You do not have to specify the exact date the list was published. The service will search forward (into the future) for the closest publication date to the date you specify. For example, a request for lists/overview/2013-05-22 will retrieve the list that was published on 05-26.
+    // 
+    // If you do not include a published_date, the current week's best-sellers lists will be returned.
     string published_date = 3;
 }
 
@@ -194,20 +234,36 @@ message GetListsOverviewformatResponse {
 }
 
 message GetListsDateListRequest {
+    // YYYY-MM-DD
+    // 
+    // The week-ending date for the sales reflected on list-name. Times best-seller lists are compiled using available book sale data. The bestsellers-date may be significantly earlier than published-date. For additional information, see the explanation at the bottom of any best-seller list page on NYTimes.com (example: Hardcover Fiction, published Dec. 5 but reflecting sales to Nov. 29).
     string bestsellers_date = 1;
     string date = 2;
+    // International Standard Book Number, 10 or 13 digits
     int32 isbn = 3;
+    // Name of the Best Sellers List. You can get the full list from /lists/names.json
     string list = 4;
+    // The name of the Times best-seller list. To get valid values, use a list names request.
+    // 
+    // Be sure to replace spaces with hyphens (e.g., e-book-fiction or hardcover-fiction, not E-Book Fiction or Hardcover Fiction). (The parameter is not case sensitive.)
     string list_name = 5;
+    // Sets the starting point of the result set
     int32 offset = 6;
+    // YYYY-MM-DD
+    // 
+    // The date the best-seller list was published on NYTimes.com (compare bestsellers-date)
     string published_date = 7;
+    // The rank of the best seller on list-name as of bestsellers-date
     string rank = 8;
+    // The rank of the best seller on list-name one week prior to bestsellers-date
     int32 rank_last_week = 9;
+    // The default is ASC (ascending). The sort-order parameter is used with the sort-by parameter — for details, see each request type.
     enum GetListsDateListRequest_Sort_order {
         GETLISTSDATELISTREQUEST_SORT_ORDER_ASC = 0;
         GETLISTSDATELISTREQUEST_SORT_ORDER_DESC = 1;
     }
     GetListsDateListRequest_Sort_order sort_order = 10;
+    // The number of weeks that the best seller has been on list-name, as of bestsellers-date
     int32 weeks_on_list = 11;
 }
 
@@ -261,13 +317,16 @@ message GetListsDateListResponse {
 
 message GetReviewsformatRequest {
     string api_key = 1;
+    // You’ll need to enter the author’s first and last name, separated by a space. This space will be converted into the characters %20.
     string author = 2;
     enum GetReviewsformatRequest_Format {
         GETREVIEWSFORMATREQUEST_FORMAT_JSON = 0;
         GETREVIEWSFORMATREQUEST_FORMAT_JSONP = 1;
     }
     GetReviewsformatRequest_Format format = 3;
+    // Searching by ISBN is the recommended method. You can enter 10- or 13-digit ISBNs.
     int32 isbn = 4;
+    // You’ll need to enter the full title of the book. Spaces in the title will be converted into the characters %20.
     string title = 5;
 }
 
@@ -288,10 +347,16 @@ message GetReviewsformatResponse {
 }
 
 service BooksAPIService {
+    // Best Seller List
     rpc GetListsformat(GetListsformatRequest) returns (GetListsformatResponse) {}
+    // Best Seller History List
     rpc GetListsBestSellersHistory(GetListsBestSellersHistoryRequest) returns (GetListsBestSellersHistoryResponse) {}
+    // Best Seller List Names
     rpc GetListsNamesformat(GetListsNamesformatRequest) returns (GetListsNamesformatResponse) {}
+    // Best Seller List Overview
     rpc GetListsOverviewformat(GetListsOverviewformatRequest) returns (GetListsOverviewformatResponse) {}
+    // Best Seller List by Date
     rpc GetListsDateList(GetListsDateListRequest) returns (GetListsDateListResponse) {}
+    // Reviews
     rpc GetReviewsformat(GetReviewsformatRequest) returns (GetReviewsformatResponse) {}
 }

--- a/fixtures/most_popular-options.proto
+++ b/fixtures/most_popular-options.proto
@@ -164,16 +164,19 @@ enum TimePeriod {
 }
 
 service TheMostPopularAPIService {
+    // Most Emailed by Section & Time Period
     rpc GetMostemailedSectionTimePeriod(GetMostemailedSectionTimePeriodRequest) returns (GetMostemailedSectionTimePeriodResponse) {
       option (google.api.http) = {
         get: "/svc/mostpopular/v2/mostemailed/{section}/{time-period}.json"
       };
     }
+    // Most Shared by Section & Time Period
     rpc GetMostsharedSectionTimePeriod(GetMostsharedSectionTimePeriodRequest) returns (GetMostsharedSectionTimePeriodResponse) {
       option (google.api.http) = {
         get: "/svc/mostpopular/v2/mostshared/{section}/{time-period}.json"
       };
     }
+    // Most Viewed by Section & Time Period
     rpc GetMostviewedSectionTimePeriod(GetMostviewedSectionTimePeriodRequest) returns (GetMostviewedSectionTimePeriodResponse) {
       option (google.api.http) = {
         get: "/svc/mostpopular/v2/mostviewed/{section}/{time-period}.json"

--- a/fixtures/most_popular.proto
+++ b/fixtures/most_popular.proto
@@ -162,7 +162,10 @@ enum TimePeriod {
 }
 
 service TheMostPopularAPIService {
+    // Most Emailed by Section & Time Period
     rpc GetMostemailedSectionTimePeriod(GetMostemailedSectionTimePeriodRequest) returns (GetMostemailedSectionTimePeriodResponse) {}
+    // Most Shared by Section & Time Period
     rpc GetMostsharedSectionTimePeriod(GetMostsharedSectionTimePeriodRequest) returns (GetMostsharedSectionTimePeriodResponse) {}
+    // Most Viewed by Section & Time Period
     rpc GetMostviewedSectionTimePeriod(GetMostviewedSectionTimePeriodRequest) returns (GetMostviewedSectionTimePeriodResponse) {}
 }

--- a/fixtures/semantic_api-options.proto
+++ b/fixtures/semantic_api-options.proto
@@ -223,19 +223,16 @@ message TestModel {
 }
 
 service TheSemanticAPIService {
-
     rpc GetConceptSearch(GetConceptSearchRequest) returns (GetConceptSearchResponse) {
       option (google.api.http) = {
         get: "/svc/semantic/v2/concept/concept/search.json"
       };
     }
-
     rpc GetNameConceptTypeSpecificConcept(GetNameConceptTypeSpecificConceptRequest) returns (GetNameConceptTypeSpecificConceptResponse) {
       option (google.api.http) = {
         get: "/svc/semantic/v2/concept/name/{concept-type}/{specific-concept}.json"
       };
     }
-
     rpc GetSomethingBlah(google.protobuf.Empty) returns (google.protobuf.Empty) {
       option (google.api.http) = {
         get: "/svc/semantic/v2/concept/something/blah.json"

--- a/fixtures/semantic_api-options.proto
+++ b/fixtures/semantic_api-options.proto
@@ -15,6 +15,19 @@ import "something.proto";
 package thesemanticapi;
 
 message GetConceptSearchRequest {
+    // "all" or comma-separated list of specific optional fields: pages, ticker_symbol, links, taxonomy, combinations, geocodes, article_list, scope_notes, search_api_query
+    // 
+    // Optional fields are returned in result_set. They are briefly explained here:
+    // 
+    // pages: A list of topic pages associated with a specific concept.
+    // ticker_symbol: If this concept is a publicly traded company, this field contains the ticker symbol.
+    // links: A list of links from this concept to external data resources.
+    // taxonomy: For descriptor concepts, this field returns a list of taxonomic relations to other concepts.
+    // combinations: For descriptor concepts, this field returns a list of the specific meanings tis concept takes on when combined with other concepts.
+    // geocodes: For geographic concepts, the full GIS record from geonames.
+    // article_list: A list of up to 10 articles associated with this concept.
+    // scope_notes: Scope notes contains clarifications and meaning definitions that explicate the relationship between the concept and an article.
+    // search_api_query: Returns the request one would need to submit to the Article Search API to obtain a list of articles annotated with this concept.
     enum GetConceptSearchRequest_Field {
         GETCONCEPTSEARCHREQUEST_FIELD_ALL = 0;
         GETCONCEPTSEARCHREQUEST_FIELD_PAGES = 1;
@@ -28,7 +41,9 @@ message GetConceptSearchRequest {
         GETCONCEPTSEARCHREQUEST_FIELD_SEARCH_API_QUERY = 9;
     }
     GetConceptSearchRequest_Field fields = 1;
+    // Integer value for the index count from the first concept to the last concept, sorted alphabetically. Used in a Search Query. A Search Query will return up to 10 concepts in its results.
     int32 offset = 2;
+    // Precedes the search term string. Used in a Search Query. Except for <specific_concept_name>, Search Query will take the required parameters listed above (<concept_type>, <concept_uri>, <article_uri>) as an optional_parameter in addition to the query=<query_term>.
     string query = 3;
 }
 
@@ -41,6 +56,19 @@ message GetConceptSearchResponse {
 
 message GetNameConceptTypeSpecificConceptRequest {
     ConceptTypeParam concept_type = 1;
+    // "all" or comma-separated list of specific optional fields: pages, ticker_symbol, links, taxonomy, combinations, geocodes, article_list, scope_notes, search_api_query
+    // 
+    // Optional fields are returned in result_set. They are briefly explained here:
+    // 
+    // pages: A list of topic pages associated with a specific concept.
+    // ticker_symbol: If this concept is a publicly traded company, this field contains the ticker symbol.
+    // links: A list of links from this concept to external data resources.
+    // taxonomy: For descriptor concepts, this field returns a list of taxonomic relations to other concepts.
+    // combinations: For descriptor concepts, this field returns a list of the specific meanings tis concept takes on when combined with other concepts.
+    // geocodes: For geographic concepts, the full GIS record from geonames.
+    // article_list: A list of up to 10 articles associated with this concept.
+    // scope_notes: Scope notes contains clarifications and meaning definitions that explicate the relationship between the concept and an article.
+    // search_api_query: Returns the request one would need to submit to the Article Search API to obtain a list of articles annotated with this concept.
     enum GetNameConceptTypeSpecificConceptRequest_Field {
         GETNAMECONCEPTTYPESPECIFICCONCEPTREQUEST_FIELD_ALL = 0;
         GETNAMECONCEPTTYPESPECIFICCONCEPTREQUEST_FIELD_PAGES = 1;
@@ -54,6 +82,7 @@ message GetNameConceptTypeSpecificConceptRequest {
         GETNAMECONCEPTTYPESPECIFICCONCEPTREQUEST_FIELD_SEARCH_API_QUERY = 9;
     }
     GetNameConceptTypeSpecificConceptRequest_Field fields = 2;
+    // Precedes the search term string. Used in a Search Query. Except for <specific_concept_name>, Search Query will take the required parameters listed above (<concept_type>, <concept_uri>, <article_uri>) as an optional_parameter in addition to the query=<query_term>.
     string query = 3;
     string specific_concept = 4;
 }
@@ -194,16 +223,19 @@ message TestModel {
 }
 
 service TheSemanticAPIService {
+
     rpc GetConceptSearch(GetConceptSearchRequest) returns (GetConceptSearchResponse) {
       option (google.api.http) = {
         get: "/svc/semantic/v2/concept/concept/search.json"
       };
     }
+
     rpc GetNameConceptTypeSpecificConcept(GetNameConceptTypeSpecificConceptRequest) returns (GetNameConceptTypeSpecificConceptResponse) {
       option (google.api.http) = {
         get: "/svc/semantic/v2/concept/name/{concept-type}/{specific-concept}.json"
       };
     }
+
     rpc GetSomethingBlah(google.protobuf.Empty) returns (google.protobuf.Empty) {
       option (google.api.http) = {
         get: "/svc/semantic/v2/concept/something/blah.json"

--- a/fixtures/semantic_api.proto
+++ b/fixtures/semantic_api.proto
@@ -13,6 +13,19 @@ import "something.proto";
 package thesemanticapi;
 
 message GetConceptSearchRequest {
+    // "all" or comma-separated list of specific optional fields: pages, ticker_symbol, links, taxonomy, combinations, geocodes, article_list, scope_notes, search_api_query
+    // 
+    // Optional fields are returned in result_set. They are briefly explained here:
+    // 
+    // pages: A list of topic pages associated with a specific concept.
+    // ticker_symbol: If this concept is a publicly traded company, this field contains the ticker symbol.
+    // links: A list of links from this concept to external data resources.
+    // taxonomy: For descriptor concepts, this field returns a list of taxonomic relations to other concepts.
+    // combinations: For descriptor concepts, this field returns a list of the specific meanings tis concept takes on when combined with other concepts.
+    // geocodes: For geographic concepts, the full GIS record from geonames.
+    // article_list: A list of up to 10 articles associated with this concept.
+    // scope_notes: Scope notes contains clarifications and meaning definitions that explicate the relationship between the concept and an article.
+    // search_api_query: Returns the request one would need to submit to the Article Search API to obtain a list of articles annotated with this concept.
     enum GetConceptSearchRequest_Field {
         GETCONCEPTSEARCHREQUEST_FIELD_ALL = 0;
         GETCONCEPTSEARCHREQUEST_FIELD_PAGES = 1;
@@ -26,7 +39,9 @@ message GetConceptSearchRequest {
         GETCONCEPTSEARCHREQUEST_FIELD_SEARCH_API_QUERY = 9;
     }
     GetConceptSearchRequest_Field fields = 1;
+    // Integer value for the index count from the first concept to the last concept, sorted alphabetically. Used in a Search Query. A Search Query will return up to 10 concepts in its results.
     int32 offset = 2;
+    // Precedes the search term string. Used in a Search Query. Except for <specific_concept_name>, Search Query will take the required parameters listed above (<concept_type>, <concept_uri>, <article_uri>) as an optional_parameter in addition to the query=<query_term>.
     string query = 3;
 }
 
@@ -39,6 +54,19 @@ message GetConceptSearchResponse {
 
 message GetNameConceptTypeSpecificConceptRequest {
     ConceptTypeParam concept_type = 1;
+    // "all" or comma-separated list of specific optional fields: pages, ticker_symbol, links, taxonomy, combinations, geocodes, article_list, scope_notes, search_api_query
+    // 
+    // Optional fields are returned in result_set. They are briefly explained here:
+    // 
+    // pages: A list of topic pages associated with a specific concept.
+    // ticker_symbol: If this concept is a publicly traded company, this field contains the ticker symbol.
+    // links: A list of links from this concept to external data resources.
+    // taxonomy: For descriptor concepts, this field returns a list of taxonomic relations to other concepts.
+    // combinations: For descriptor concepts, this field returns a list of the specific meanings tis concept takes on when combined with other concepts.
+    // geocodes: For geographic concepts, the full GIS record from geonames.
+    // article_list: A list of up to 10 articles associated with this concept.
+    // scope_notes: Scope notes contains clarifications and meaning definitions that explicate the relationship between the concept and an article.
+    // search_api_query: Returns the request one would need to submit to the Article Search API to obtain a list of articles annotated with this concept.
     enum GetNameConceptTypeSpecificConceptRequest_Field {
         GETNAMECONCEPTTYPESPECIFICCONCEPTREQUEST_FIELD_ALL = 0;
         GETNAMECONCEPTTYPESPECIFICCONCEPTREQUEST_FIELD_PAGES = 1;
@@ -52,6 +80,7 @@ message GetNameConceptTypeSpecificConceptRequest {
         GETNAMECONCEPTTYPESPECIFICCONCEPTREQUEST_FIELD_SEARCH_API_QUERY = 9;
     }
     GetNameConceptTypeSpecificConceptRequest_Field fields = 2;
+    // Precedes the search term string. Used in a Search Query. Except for <specific_concept_name>, Search Query will take the required parameters listed above (<concept_type>, <concept_uri>, <article_uri>) as an optional_parameter in addition to the query=<query_term>.
     string query = 3;
     string specific_concept = 4;
 }
@@ -192,7 +221,10 @@ message TestModel {
 }
 
 service TheSemanticAPIService {
+
     rpc GetConceptSearch(GetConceptSearchRequest) returns (GetConceptSearchResponse) {}
+
     rpc GetNameConceptTypeSpecificConcept(GetNameConceptTypeSpecificConceptRequest) returns (GetNameConceptTypeSpecificConceptResponse) {}
+
     rpc GetSomethingBlah(google.protobuf.Empty) returns (google.protobuf.Empty) {}
 }

--- a/fixtures/semantic_api.proto
+++ b/fixtures/semantic_api.proto
@@ -221,10 +221,7 @@ message TestModel {
 }
 
 service TheSemanticAPIService {
-
     rpc GetConceptSearch(GetConceptSearchRequest) returns (GetConceptSearchResponse) {}
-
     rpc GetNameConceptTypeSpecificConcept(GetNameConceptTypeSpecificConceptRequest) returns (GetNameConceptTypeSpecificConceptResponse) {}
-
     rpc GetSomethingBlah(google.protobuf.Empty) returns (google.protobuf.Empty) {}
 }

--- a/fixtures/spec-options.proto
+++ b/fixtures/spec-options.proto
@@ -7,9 +7,13 @@ import "google/api/annotations.proto";
 package uberapi;
 
 message GetEstimatesPriceRequest {
+    // Latitude component of end location.
     double end_latitude = 1;
+    // Longitude component of end location.
     double end_longitude = 2;
+    // Latitude component of start location.
     double start_latitude = 3;
+    // Longitude component of start location.
     double start_longitude = 4;
 }
 
@@ -18,9 +22,13 @@ message GetEstimatesPriceResponse {
 }
 
 message GetEstimatesTimeRequest {
+    // Unique customer identifier to be used for experience customization.
     string customer_uuid = 1;
+    // Unique identifier representing a specific product for a given latitude & longitude.
     string product_id = 2;
+    // Latitude component of start location.
     double start_latitude = 3;
+    // Longitude component of start location.
     double start_longitude = 4;
 }
 
@@ -29,7 +37,9 @@ message GetEstimatesTimeResponse {
 }
 
 message GetHistoryRequest {
+    // Number of items to retrieve. Default is 5, maximum is 100.
     int32 limit = 1;
+    // Offset the list of returned results by this amount. Default is zero.
     int32 offset = 2;
 }
 
@@ -38,7 +48,9 @@ message PutMeRequest {
 }
 
 message GetProductsRequest {
+    // Latitude component of location.
     double latitude = 1;
+    // Longitude component of location.
     double longitude = 2;
 }
 
@@ -47,13 +59,17 @@ message GetProductsResponse {
 }
 
 message Activities {
+    // Total number of items available.
     int32 count = 1;
     repeated Activity history = 2;
+    // Number of items to retrieve (100 max).
     int32 limit = 3;
+    // Position in pagination.
     int32 offset = 4;
 }
 
 message Activity {
+    // Unique identifier for the activity
     string uuid = 1;
 }
 
@@ -64,58 +80,103 @@ message Error {
 }
 
 message PriceEstimate {
+    // [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code.
     string currency_code = 1;
+    // Display name of product.
     string display_name = 2;
+    // Formatted string of estimate in local currency of the start location. Estimate could be a range, a single number (flat rate) or "Metered" for TAXI.
     string estimate = 3;
+    // Upper bound of the estimated price.
     int32 high_estimate = 4;
+    // Lower bound of the estimated price.
     int32 low_estimate = 5;
+    // Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles
     string product_id = 6;
+    // Expected surge multipflier. Surge is active if surge_multiplier is greater than 1. Price estimate already factors in the surge multiplier.
     int32 surge_multiplier = 7;
 }
 
 message Product {
+    // Capacity of product. For example, 4 people.
     string capacity = 1;
+    // Description of product.
     string description = 2;
+    // Display name of product.
     string display_name = 3;
+    // Image URL representing the product.
     string image = 4;
+    // Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
     string product_id = 5;
 }
 
 message Profile {
+    // Email address of the Uber user
     string email = 1;
+    // First name of the Uber user.
     string first_name = 2;
+    // Last name of the Uber user.
     string last_name = 3;
+    // Image URL of the Uber user.
     string picture = 4;
+    // Promo code of the Uber user.
     string promo_code = 5;
 }
 
 service UberAPIService {
+    // Price Estimates
+    // 
+    // The Price Estimates endpoint returns an estimated price range
+    // for each product offered at a given location. The price estimate is
+    // provided as a formatted string with the full price range and the localized
+    // currency symbol.<br><br>The response also includes low and high estimates,
+    // and the [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code for
+    // situations requiring currency conversion. When surge is active for a particular
+    // product, its surge_multiplier will be greater than 1, but the price estimate
+    // already factors in this multiplier.
     rpc GetEstimatesPrice(GetEstimatesPriceRequest) returns (GetEstimatesPriceResponse) {
       option (google.api.http) = {
         get: "/v1/estimates/price"
       };
     }
+    // Time Estimates
+    // 
+    // The Time Estimates endpoint returns ETAs for all products offered at a given location, with the responses expressed as integers in seconds. We recommend that this endpoint be called every minute to provide the most accurate, up-to-date ETAs.
     rpc GetEstimatesTime(GetEstimatesTimeRequest) returns (GetEstimatesTimeResponse) {
       option (google.api.http) = {
         get: "/v1/estimates/time"
       };
     }
+    // User Activity
+    // 
+    // The User Activity endpoint returns data about a user's lifetime activity with Uber. The response will include pickup locations and times, dropoff locations and times, the distance of past requests, and information about which products were requested.<br><br>The history array in the response will have a maximum length based on the limit parameter. The response value count may exceed limit, therefore subsequent API requests may be necessary.
     rpc GetHistory(GetHistoryRequest) returns (Activities) {
       option (google.api.http) = {
         get: "/v1/history"
       };
     }
+    // User Profile
+    // 
+    // The User Profile endpoint returns information about the Uber user that has authorized with the application.
     rpc GetMe(google.protobuf.Empty) returns (Profile) {
       option (google.api.http) = {
         get: "/v1/me"
       };
     }
+    // Save User Profile
+    // 
+    // The User Profile endpoint returns information about the Uber user that has authorized with the application.
     rpc PutMe(PutMeRequest) returns (Profile) {
       option (google.api.http) = {
         put: "/v1/me"
         body: "profile"
       };
     }
+    // Product Types
+    // 
+    // The Products endpoint returns information about the *Uber* products
+    // offered at a given location. The response includes the display name
+    // and other details about each product, and lists the products in the
+    // proper display order.
     rpc GetProducts(GetProductsRequest) returns (GetProductsResponse) {
       option (google.api.http) = {
         get: "/v1/products"

--- a/fixtures/spec.proto
+++ b/fixtures/spec.proto
@@ -5,9 +5,13 @@ import "google/protobuf/empty.proto";
 package uberapi;
 
 message GetEstimatesPriceRequest {
+    // Latitude component of end location.
     double end_latitude = 1;
+    // Longitude component of end location.
     double end_longitude = 2;
+    // Latitude component of start location.
     double start_latitude = 3;
+    // Longitude component of start location.
     double start_longitude = 4;
 }
 
@@ -16,9 +20,13 @@ message GetEstimatesPriceResponse {
 }
 
 message GetEstimatesTimeRequest {
+    // Unique customer identifier to be used for experience customization.
     string customer_uuid = 1;
+    // Unique identifier representing a specific product for a given latitude & longitude.
     string product_id = 2;
+    // Latitude component of start location.
     double start_latitude = 3;
+    // Longitude component of start location.
     double start_longitude = 4;
 }
 
@@ -27,7 +35,9 @@ message GetEstimatesTimeResponse {
 }
 
 message GetHistoryRequest {
+    // Number of items to retrieve. Default is 5, maximum is 100.
     int32 limit = 1;
+    // Offset the list of returned results by this amount. Default is zero.
     int32 offset = 2;
 }
 
@@ -36,7 +46,9 @@ message PutMeRequest {
 }
 
 message GetProductsRequest {
+    // Latitude component of location.
     double latitude = 1;
+    // Longitude component of location.
     double longitude = 2;
 }
 
@@ -45,13 +57,17 @@ message GetProductsResponse {
 }
 
 message Activities {
+    // Total number of items available.
     int32 count = 1;
     repeated Activity history = 2;
+    // Number of items to retrieve (100 max).
     int32 limit = 3;
+    // Position in pagination.
     int32 offset = 4;
 }
 
 message Activity {
+    // Unique identifier for the activity
     string uuid = 1;
 }
 
@@ -62,36 +78,81 @@ message Error {
 }
 
 message PriceEstimate {
+    // [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code.
     string currency_code = 1;
+    // Display name of product.
     string display_name = 2;
+    // Formatted string of estimate in local currency of the start location. Estimate could be a range, a single number (flat rate) or "Metered" for TAXI.
     string estimate = 3;
+    // Upper bound of the estimated price.
     int32 high_estimate = 4;
+    // Lower bound of the estimated price.
     int32 low_estimate = 5;
+    // Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles
     string product_id = 6;
+    // Expected surge multipflier. Surge is active if surge_multiplier is greater than 1. Price estimate already factors in the surge multiplier.
     int32 surge_multiplier = 7;
 }
 
 message Product {
+    // Capacity of product. For example, 4 people.
     string capacity = 1;
+    // Description of product.
     string description = 2;
+    // Display name of product.
     string display_name = 3;
+    // Image URL representing the product.
     string image = 4;
+    // Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
     string product_id = 5;
 }
 
 message Profile {
+    // Email address of the Uber user
     string email = 1;
+    // First name of the Uber user.
     string first_name = 2;
+    // Last name of the Uber user.
     string last_name = 3;
+    // Image URL of the Uber user.
     string picture = 4;
+    // Promo code of the Uber user.
     string promo_code = 5;
 }
 
 service UberAPIService {
+    // Price Estimates
+    // 
+    // The Price Estimates endpoint returns an estimated price range
+    // for each product offered at a given location. The price estimate is
+    // provided as a formatted string with the full price range and the localized
+    // currency symbol.<br><br>The response also includes low and high estimates,
+    // and the [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code for
+    // situations requiring currency conversion. When surge is active for a particular
+    // product, its surge_multiplier will be greater than 1, but the price estimate
+    // already factors in this multiplier.
     rpc GetEstimatesPrice(GetEstimatesPriceRequest) returns (GetEstimatesPriceResponse) {}
+    // Time Estimates
+    // 
+    // The Time Estimates endpoint returns ETAs for all products offered at a given location, with the responses expressed as integers in seconds. We recommend that this endpoint be called every minute to provide the most accurate, up-to-date ETAs.
     rpc GetEstimatesTime(GetEstimatesTimeRequest) returns (GetEstimatesTimeResponse) {}
+    // User Activity
+    // 
+    // The User Activity endpoint returns data about a user's lifetime activity with Uber. The response will include pickup locations and times, dropoff locations and times, the distance of past requests, and information about which products were requested.<br><br>The history array in the response will have a maximum length based on the limit parameter. The response value count may exceed limit, therefore subsequent API requests may be necessary.
     rpc GetHistory(GetHistoryRequest) returns (Activities) {}
+    // User Profile
+    // 
+    // The User Profile endpoint returns information about the Uber user that has authorized with the application.
     rpc GetMe(google.protobuf.Empty) returns (Profile) {}
+    // Save User Profile
+    // 
+    // The User Profile endpoint returns information about the Uber user that has authorized with the application.
     rpc PutMe(PutMeRequest) returns (Profile) {}
+    // Product Types
+    // 
+    // The Products endpoint returns information about the *Uber* products
+    // offered at a given location. The response includes the display name
+    // and other details about each product, and lists the products in the
+    // proper display order.
     rpc GetProducts(GetProductsRequest) returns (GetProductsResponse) {}
 }

--- a/openapi.go
+++ b/openapi.go
@@ -438,6 +438,9 @@ var lineStart = regexp.MustCompile(`^`)
 var newLine = regexp.MustCompile(`\n`)
 
 func prepComment(comment, space string) string {
+	if comment == "" {
+		return ""
+	}
 	comment = lineStart.ReplaceAllString(comment, space+"// ")
 	comment = newLine.ReplaceAllString(comment, "\n"+space+"// ")
 	comment = strings.TrimRight(comment, "/ ")

--- a/openapi.go
+++ b/openapi.go
@@ -65,6 +65,7 @@ type Model struct {
 
 // Items represent Model properties in an OpenAPI spec.
 type Items struct {
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
 	// scalar
 	Type   interface{} `yaml:"type" json:"type"`
 	Format interface{} `yaml:"format,omitempty" json:"format,omitempty"`
@@ -87,6 +88,14 @@ type Items struct {
 
 	// is an other Model
 	Model `yaml:",inline"`
+}
+
+func (i Items) Comment() string {
+	return prepComment(i.Description, "    ")
+}
+
+func (i Items) HasComment() bool {
+	return i.Description != ""
 }
 
 func protoScalarType(name string, typ, frmt interface{}, indx int) string {
@@ -425,6 +434,19 @@ func includeBody(parent, child Parameters) string {
 	return ""
 }
 
+var lineStart = regexp.MustCompile(`^`)
+var newLine = regexp.MustCompile(`\n`)
+
+func prepComment(comment, space string) string {
+	comment = lineStart.ReplaceAllString(comment, space+"// ")
+	comment = newLine.ReplaceAllString(comment, "\n"+space+"// ")
+	comment = strings.TrimRight(comment, "/ ")
+	if !strings.HasSuffix(comment, "\n") {
+		comment += "\n"
+	}
+	return comment
+}
+
 func (e *Endpoint) protoEndpoint(annotate bool, parentParams Parameters, base, path, method string) string {
 	reqName := "google.protobuf.Empty"
 	endpointName := pathMethodToName(path, method)
@@ -443,6 +465,20 @@ func (e *Endpoint) protoEndpoint(annotate bool, parentParams Parameters, base, p
 		respName = resp.responseName(endpointName)
 	}
 
+	comment := e.Summary
+	if comment != "" && e.Description != "" {
+		if !strings.HasSuffix(comment, "\n") {
+			comment += "\n"
+		}
+		comment += "\n"
+	}
+
+	if e.Description != "" {
+		comment += e.Description
+	}
+
+	comment = prepComment(comment, "    ")
+
 	tData := struct {
 		Annotate     bool
 		Method       string
@@ -452,6 +488,8 @@ func (e *Endpoint) protoEndpoint(annotate bool, parentParams Parameters, base, p
 		Path         string
 		IncludeBody  bool
 		BodyAttr     string
+		Comment      string
+		HasComment   bool
 	}{
 		annotate,
 		method,
@@ -461,6 +499,8 @@ func (e *Endpoint) protoEndpoint(annotate bool, parentParams Parameters, base, p
 		path,
 		(bodyAttr != ""),
 		bodyAttr,
+		comment,
+		(comment != ""),
 	}
 
 	var b bytes.Buffer

--- a/proto.go
+++ b/proto.go
@@ -89,7 +89,7 @@ service {{ serviceName .Info.Title }} {{"{"}}{{ range $path, $endpoint := .Paths
 }
 `
 
-const protoEndpointTmplStr = `    rpc {{ .Name }}({{ .RequestName }}) returns ({{ .ResponseName }}) {{"{"}}{{ if .Annotate }}
+const protoEndpointTmplStr = `{{ if .HasComment }}{{ .Comment }}{{ end }}    rpc {{ .Name }}({{ .RequestName }}) returns ({{ .ResponseName }}) {{"{"}}{{ if .Annotate }}
       option (google.api.http) = {
         {{ .Method }}: "{{ .Path }}"{{ if .IncludeBody }}
         body: "{{ .BodyAttr }}"{{ end }}
@@ -97,7 +97,7 @@ const protoEndpointTmplStr = `    rpc {{ .Name }}({{ .RequestName }}) returns ({
     {{ end }}{{"}"}}`
 
 const protoMsgTmplStr = `{{ $i := counter }}{{ $defs := .Defs }}{{ $msgName := .Name }}{{ $depth := .Depth }}message {{ .Name }} {{"{"}}{{ range $propName, $prop := .Properties }}
-{{ indent $depth }}    {{ $prop.ProtoMessage $msgName $propName $defs $i $depth }};{{ end }}
+{{ indent $depth }}{{ if $prop.HasComment }}{{ indent $depth }}{{ $prop.Comment }}{{ end }}    {{ $prop.ProtoMessage $msgName $propName $defs $i $depth }};{{ end }}
 {{ indent $depth }}}`
 
 const protoEnumTmplStr = `{{ $i := zcounter }}{{ $depth := .Depth }}{{ $name := .Name }}enum {{ .Name }} {{"{"}}{{ range $index, $pName := .Enum }}

--- a/proto_test.go
+++ b/proto_test.go
@@ -207,7 +207,8 @@ func TestGenerateProto(t *testing.T) {
 		}
 
 		if string(want) != string(protoResult) {
-			t.Errorf("testYaml expected:\n%q\nGOT:\n%q", want, protoResult)
+			t.Errorf("testYaml (%s) expected:\n%s\nGOT:\n%s",
+				test.givenFixturePath, want, protoResult)
 		}
 	}
 }


### PR DESCRIPTION
I've verified that `protoc` also carries these over to the generated .pb.go files.

Resolves #13 

I took far too long to resolve this one, my bad. 