### PR TITLE
Strip out any query string from paths when generating proto names.

### DIFF
--- a/fixtures/includes_query.json
+++ b/fixtures/includes_query.json
@@ -1,0 +1,49 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Bad API",
+    "description": "Bad API using query parameters",
+    "version": "1.0.0"
+  },
+  "host": "api.badness.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/v1",
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/bad/path/with/query?badness={badness}": {
+      "get": {
+        "summary": "Bad Call",
+        "description": "Call which includes a query in its path.",
+        "parameters": [
+          {
+            "name": "badness",
+            "in": "query",
+            "description": "Bad parameter.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An array of strings",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Item"
+              }
+            }
+          }
+        }
+      }
+    }
+	},
+	"definitions": {
+		"Item": {
+			"type": "string"
+		}
+	}
+}

--- a/fixtures/includes_query.proto
+++ b/fixtures/includes_query.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package badapi;
+
+message GetBadPathWithQueryRequest {
+    // Bad parameter.
+    string badness = 1;
+}
+
+message GetBadPathWithQueryResponse {
+    repeated string items = 1;
+}
+
+service BadAPIService {
+    // Bad Call
+    // 
+    // Call which includes a query in its path.
+    rpc GetBadPathWithQuery(GetBadPathWithQueryRequest) returns (GetBadPathWithQueryResponse) {}
+}

--- a/openapi.go
+++ b/openapi.go
@@ -392,7 +392,9 @@ func pathMethodToName(path, method string) string {
 	path = strings.Replace(path, "-", " ", -1)
 	path = strings.Replace(path, ".", " ", -1)
 	path = strings.Replace(path, "/", " ", -1)
-	re := regexp.MustCompile(`[\{\}\[\]()/\.]`)
+	// Strip out illegal-for-identifier characters in the path, including any query string.
+	// Note that query strings are illegal in swagger paths, but some tooling seems to tolerate them.
+	re := regexp.MustCompile(`[\{\}\[\]()/\.]|\?.*`)
 	path = re.ReplaceAllString(path, "")
 	for _, nme := range strings.Fields(path) {
 		name += strings.Title(nme)

--- a/proto_test.go
+++ b/proto_test.go
@@ -185,6 +185,13 @@ func TestGenerateProto(t *testing.T) {
 			"fixtures/spec-options.proto",
 		},
 		{
+			false,
+			false,
+			"fixtures/includes_query.json",
+
+			"fixtures/includes_query.proto",
+		},
+		{
 			true,
 			false,
 			"fixtures/petstore/swagger.yaml",


### PR DESCRIPTION
Fixes #31 .