### PR TITLE
Fix handling of default format for "number" types.

### DIFF
--- a/fixtures/semantic_api-options.proto
+++ b/fixtures/semantic_api-options.proto
@@ -211,7 +211,7 @@ message TestModel {
     map<string, TestModel> test_map_object = 11;
     map<string, string> test_map_scalar = 12;
     google.protobuf.DoubleValue test_num_value = 5;
-    google.protobuf.Int32Value test_numer_value = 6;
+    google.protobuf.DoubleValue test_numer_value = 6;
     google.protobuf.StringValue test_string_value = 8;
 }
 

--- a/fixtures/semantic_api.proto
+++ b/fixtures/semantic_api.proto
@@ -209,7 +209,7 @@ message TestModel {
     map<string, TestModel> test_map_object = 11;
     map<string, string> test_map_scalar = 12;
     google.protobuf.DoubleValue test_num_value = 5;
-    google.protobuf.Int32Value test_numer_value = 6;
+    google.protobuf.DoubleValue test_numer_value = 6;
     google.protobuf.StringValue test_string_value = 8;
 }
 

--- a/fixtures/spec-options.proto
+++ b/fixtures/spec-options.proto
@@ -87,13 +87,13 @@ message PriceEstimate {
     // Formatted string of estimate in local currency of the start location. Estimate could be a range, a single number (flat rate) or "Metered" for TAXI.
     string estimate = 3;
     // Upper bound of the estimated price.
-    int32 high_estimate = 4;
+    double high_estimate = 4;
     // Lower bound of the estimated price.
-    int32 low_estimate = 5;
+    double low_estimate = 5;
     // Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles
     string product_id = 6;
     // Expected surge multipflier. Surge is active if surge_multiplier is greater than 1. Price estimate already factors in the surge multiplier.
-    int32 surge_multiplier = 7;
+    double surge_multiplier = 7;
 }
 
 message Product {

--- a/fixtures/spec.proto
+++ b/fixtures/spec.proto
@@ -85,13 +85,13 @@ message PriceEstimate {
     // Formatted string of estimate in local currency of the start location. Estimate could be a range, a single number (flat rate) or "Metered" for TAXI.
     string estimate = 3;
     // Upper bound of the estimated price.
-    int32 high_estimate = 4;
+    double high_estimate = 4;
     // Lower bound of the estimated price.
-    int32 low_estimate = 5;
+    double low_estimate = 5;
     // Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles
     string product_id = 6;
     // Expected surge multipflier. Surge is active if surge_multiplier is greater than 1. Price estimate already factors in the surge multiplier.
-    int32 surge_multiplier = 7;
+    double surge_multiplier = 7;
 }
 
 message Product {

--- a/openapi.go
+++ b/openapi.go
@@ -108,7 +108,12 @@ func protoScalarType(name string, typ, frmt interface{}, indx int) string {
 			return fmt.Sprintf("string %s = %d", name, indx)
 		case "bytes":
 			return fmt.Sprintf("bytes %s = %d", name, indx)
-		case "number", "integer":
+		case "number":
+			if frmat == "" {
+				frmat = "double"
+			}
+			return fmt.Sprintf("%s %s = %d", frmat, name, indx)
+		case "integer":
 			if frmat == "" {
 				frmat = "int32"
 			}
@@ -254,7 +259,15 @@ func (i *Items) ProtoMessage(msgName, name string, defs map[string]*Items, indx 
 		switch otherTypes[0] {
 		case "string":
 			return fmt.Sprintf("google.protobuf.StringValue %s = %d", name, *indx)
-		case "number", "integer":
+		case "number":
+			frmat := format(i.Format)
+			if frmat == "" {
+				frmat = "Double"
+			} else {
+				frmat = strings.Title(frmat)
+			}
+			return fmt.Sprintf("google.protobuf.%sValue %s = %d", frmat, name, *indx)
+		case "integer":
 			frmat := format(i.Format)
 			if frmat == "" {
 				frmat = "Int32"


### PR DESCRIPTION
Fixes #36 .

Note that the test result changes look good - prices & the surge multiplier make sense as doubles.