### PR TITLE
Fixing use of referenced parameter types

### DIFF
--- a/fixtures/petstore/swagger.proto
+++ b/fixtures/petstore/swagger.proto
@@ -16,6 +16,12 @@ message PostPetsRequest {
     Pet pet = 1;
 }
 
+message GetPetsIdsRequest {
+    repeated string ids = 1;
+    // maximum number of results to return
+    int32 limit = 2;
+}
+
 message GetPetsIdRequest {
     // ID of pet to fetch
     int64 id = 1;
@@ -41,6 +47,8 @@ service SwaggerPetstoreService {
     rpc GetPets(GetPetsRequest) returns (Pets) {}
     // Creates a new pet in the store.  Duplicates are allowed
     rpc PostPets(PostPetsRequest) returns (Pet) {}
+    // Returns all pets from the system that the user has access to
+    rpc GetPetsIds(GetPetsIdsRequest) returns (Pets) {}
     // Returns a user based on a single ID, if the user does not have access to the pet
     rpc GetPetsId(GetPetsIdRequest) returns (Pet) {}
     // deletes a single pet based on the ID supplied

--- a/fixtures/petstore/swagger.yaml
+++ b/fixtures/petstore/swagger.yaml
@@ -20,6 +20,23 @@ consumes:
 produces:
   - application/json
 paths:
+  /pets/{ids}:
+    get:
+      description: |
+        Returns all pets from the system that the user has access to
+      operationId: findPets
+      parameters:
+        - $ref: '#/parameters/idsParam'
+        - $ref: 'parameters.yaml#/limitsParam'
+      responses:
+        "200":
+          description: pet response
+          schema:
+            $ref: 'Pets.yaml'
+        default:
+          description: unexpected error
+          schema:
+            $ref: 'Error.yaml'
   /pets:
     get:
       description: |
@@ -93,3 +110,15 @@ paths:
           description: unexpected error
           schema:
             $ref: 'Error.yaml'
+
+parameters:
+  idsParam:
+    name: ids
+    in: path
+    description: ids to filter by
+    required: false
+    type: array
+    collectionFormat: csv
+    items:
+      type: string
+


### PR DESCRIPTION
When a parameter with a non-scalar type was referenced in a `parameters` block via a `$ref`, the type was being listed as `array` and an erroneous `repeated` solo type was getting created outside of any message declaration.

fixes #29 