### PR TITLE
Handling string-type attributes with 'byte' format (base64-encoded byte-arrays)

### DIFF
--- a/openapi.go
+++ b/openapi.go
@@ -114,6 +114,9 @@ func protoScalarType(name string, typ, frmt interface{}, indx int) string {
 	case string:
 		switch typ.(string) {
 		case "string":
+			if frmat == "byte" {
+				return fmt.Sprintf("bytes %s = %d", name, indx)
+			}
 			return fmt.Sprintf("string %s = %d", name, indx)
 		case "bytes":
 			return fmt.Sprintf("bytes %s = %d", name, indx)


### PR DESCRIPTION
This would allow OpenAPI / Swagger definitions like this:

```
jsonbytesblob:
        type: string
        format: byte
```

which would result in a proto like this:
`bytes jsonbytesblob = 1;`

I realise that openapi2proto already supports a type called `bytes` which achieves the same thing, but this change would be more in line with the OpenAPI standards outlined here: https://swagger.io/docs/specification/data-models/data-types/#string