### PR TITLE
Support .yml file type

### DIFF
--- a/proto.go
+++ b/proto.go
@@ -100,7 +100,7 @@ func LoadDefinition(pth string) (*APIDefinition, error) {
 		err = json.Unmarshal(b, &api)
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse referened file")
+		return nil, errors.Wrap(err, "unable to parse referenced file")
 	}
 
 	// no paths or defs declared?

--- a/proto.go
+++ b/proto.go
@@ -91,7 +91,7 @@ func LoadDefinition(pth string) (*APIDefinition, error) {
 	}
 
 	var api *APIDefinition
-	pathExt = path.Ext(pth)
+	pathExt := path.Ext(pth)
 	
 	isYaml := pathExt == ".yaml" || pathExt == ".yml"
 	if isYaml {

--- a/proto.go
+++ b/proto.go
@@ -91,7 +91,9 @@ func LoadDefinition(pth string) (*APIDefinition, error) {
 	}
 
 	var api *APIDefinition
-	isYaml := path.Ext(pth) == ".yaml"
+	pathExt = path.Ext(pth)
+	
+	isYaml := pathExt == ".yaml" || pathExt == ".yml"
 	if isYaml {
 		err = yaml.Unmarshal(b, &api)
 	} else {


### PR DESCRIPTION
Hi, I was stumped for a while when passing my spec file with the following command

```bash
openapi2proto -spec swagger.yml
```

where I received a cryptic error:

> unable to load spec: unable to parse referened file: invalid character 's' looking for beginning of value

It seems like `.yml` file extensions are interpreted as JSON, so I'm making a fix to allow these extensions as well. 

(I've also taken the liberty to correct the typo in the error message)

Cheers!