### PR TITLE
Fix generating maps from YAML

### DIFF
--- a/fixtures/refs.json
+++ b/fixtures/refs.json
@@ -1,0 +1,27 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "refs"
+  },
+  "definitions": {
+    "TestModel": {
+        "type": "object",
+        "properties": {
+            "test_map_object": {
+                "type": "object",
+                "additionalProperties": {
+                    "$ref": "#/definitions/TestModel"
+                },
+                "x-proto-tag": 11
+            },
+            "test_map_scalar": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "string"
+                },
+                "x-proto-tag": 12
+            }
+        }
+    }
+  }
+}

--- a/fixtures/refs.proto
+++ b/fixtures/refs.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package refs;
+
+message TestModel {
+    map<string, TestModel> test_map_object = 11;
+    map<string, string> test_map_scalar = 12;
+}
+
+

--- a/fixtures/refs.yaml
+++ b/fixtures/refs.yaml
@@ -1,0 +1,17 @@
+swagger: '2.0'
+info:
+  title: refs
+definitions:
+  TestModel:
+    type: object
+    properties:
+      test_map_object:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/TestModel'
+        x-proto-tag: 11
+      test_map_scalar:
+        type: object
+        additionalProperties:
+          type: string
+        x-proto-tag: 12

--- a/fixtures/semantic_api.yaml
+++ b/fixtures/semantic_api.yaml
@@ -1,0 +1,410 @@
+swagger: '2.0'
+info:
+  title: The Semantic API
+  description: |
+    The Semantic API complements the Articles API. With the Semantic API, you get access to the long list of people, places, organizations and other locations, entities and descriptors that make up the controlled vocabulary used as metadata by The New York Times (sometimes referred to as Times Tags and used for Times Topics pages).
+
+    The Semantic API uses concepts which are, by definition, terms in The New York Times controlled vocabulary. Like the way facets are used in the Articles API, concepts are a good way to uncover articles of interest in The New York Times archive, and at the same time, limit the scope and number of those articles. The Semantic API maps to external semantic data resources, in a fashion consistent with the idea of linked data. The Semantic API also provides combination and relationship information to other, similar concepts in The New York Times controlled vocabulary.
+  version: 2.0.0
+host: api.nytimes.com
+schemes:
+  - http
+  - https
+basePath: /svc/semantic/v2/concept
+produces:
+  - application/json
+security:
+  - apikey: []
+paths:
+  '/name/{concept-type}/{specific-concept}.json':
+    get:
+      parameters:
+        - $ref: '#/parameters/ConceptTypeParam'
+        - $ref: '#/parameters/SpecificConceptParam'
+        - name: fields
+          in: query
+          description: |
+            "all" or comma-separated list of specific optional fields: pages, ticker_symbol, links, taxonomy, combinations, geocodes, article_list, scope_notes, search_api_query
+
+            Optional fields are returned in result_set. They are briefly explained here:
+
+            pages: A list of topic pages associated with a specific concept.
+            ticker_symbol: If this concept is a publicly traded company, this field contains the ticker symbol.
+            links: A list of links from this concept to external data resources.
+            taxonomy: For descriptor concepts, this field returns a list of taxonomic relations to other concepts.
+            combinations: For descriptor concepts, this field returns a list of the specific meanings tis concept takes on when combined with other concepts.
+            geocodes: For geographic concepts, the full GIS record from geonames.
+            article_list: A list of up to 10 articles associated with this concept.
+            scope_notes: Scope notes contains clarifications and meaning definitions that explicate the relationship between the concept and an article.
+            search_api_query: Returns the request one would need to submit to the Article Search API to obtain a list of articles annotated with this concept.
+          required: false
+          type: string
+          enum:
+            - all
+            - pages
+            - ticker_symbol
+            - links
+            - taxonomy
+            - combinations
+            - geocodes
+            - article_list
+            - scope_notes
+            - search_api_query
+        - name: query
+          in: query
+          description: 'Precedes the search term string. Used in a Search Query. Except for <specific_concept_name>, Search Query will take the required parameters listed above (<concept_type>, <concept_uri>, <article_uri>) as an optional_parameter in addition to the query=<query_term>.'
+          required: true
+          type: string
+      responses:
+        '200':
+          description: An array of Concepts
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+              copyright:
+                type: string
+              num_results:
+                type: integer
+              results:
+                type: array
+                items:
+                  $ref: '#/definitions/Concept'
+  /something/blah.json:
+    get:
+      parameters: []
+      responses:
+        '200':
+          description: this is an empty response
+  /concept/search.json:
+    get:
+      parameters:
+        - name: query
+          in: query
+          description: 'Precedes the search term string. Used in a Search Query. Except for <specific_concept_name>, Search Query will take the required parameters listed above (<concept_type>, <concept_uri>, <article_uri>) as an optional_parameter in addition to the query=<query_term>.'
+          required: true
+          type: string
+        - name: offset
+          in: query
+          description: 'Integer value for the index count from the first concept to the last concept, sorted alphabetically. Used in a Search Query. A Search Query will return up to 10 concepts in its results.'
+          default: 10
+          required: false
+          type: integer
+        - name: fields
+          in: query
+          description: |
+            "all" or comma-separated list of specific optional fields: pages, ticker_symbol, links, taxonomy, combinations, geocodes, article_list, scope_notes, search_api_query
+
+            Optional fields are returned in result_set. They are briefly explained here:
+
+            pages: A list of topic pages associated with a specific concept.
+            ticker_symbol: If this concept is a publicly traded company, this field contains the ticker symbol.
+            links: A list of links from this concept to external data resources.
+            taxonomy: For descriptor concepts, this field returns a list of taxonomic relations to other concepts.
+            combinations: For descriptor concepts, this field returns a list of the specific meanings tis concept takes on when combined with other concepts.
+            geocodes: For geographic concepts, the full GIS record from geonames.
+            article_list: A list of up to 10 articles associated with this concept.
+            scope_notes: Scope notes contains clarifications and meaning definitions that explicate the relationship between the concept and an article.
+            search_api_query: Returns the request one would need to submit to the Article Search API to obtain a list of articles annotated with this concept.
+          required: false
+          type: string
+          enum:
+            - all
+            - pages
+            - ticker_symbol
+            - links
+            - taxonomy
+            - combinations
+            - geocodes
+            - article_list
+            - scope_notes
+            - search_api_query
+      responses:
+        '200':
+          description: An array of Concepts
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+              copyright:
+                type: string
+              num_results:
+                type: integer
+              results:
+                type: array
+                items:
+                  $ref: '#/definitions/ConceptRelation'
+parameters:
+  ConceptTypeParam:
+    name: concept-type
+    in: path
+    description: |
+      The type of the concept, used for Constructing a Semantic API Request by Concept Type and Specific Concept Name. The parameter is defined as a name-value pair, as in "concept_type=[nytd_geo|nytd_per|nytd_org|nytd_des]".
+    type: string
+    enum:
+      - nytd_geo
+      - nytd_per
+      - nytd_org
+      - nytd_des
+    required: true
+  SpecificConceptParam:
+    name: specific-concept
+    in: path
+    description: |
+      The name of the concept, used for Constructing a Semantic API Request by Concept Type and Specific Concept Name. The parameter is defined in the URI path, as the element immediately preceding ".json" like with "Baseball.json".
+    required: true
+    type: string
+definitions:
+  Concept:
+    type: object
+    properties:
+      concept_id:
+        type: integer
+      concept_name:
+        type: string
+      is_times_tag:
+        type: integer
+      concept_status:
+        type: string
+      vernacular:
+        type: string
+      concept_type:
+        type: string
+      concept_created:
+        type: string
+      concept_updated:
+        type: string
+      taxonomy:
+        type: array
+        items:
+          type: object
+          properties:
+            source_concept_id:
+              type: integer
+            target_concept_id:
+              type: integer
+            source_concept_name:
+              type: string
+            target_concept_name:
+              type: string
+            source_concept_type:
+              type: string
+            target_concept_type:
+              type: string
+            source_concept_vernacular:
+              type: string
+            target_concept_vernacular:
+              type: string
+            taxonomic_relation:
+              type: string
+            taxonomic_verification_status:
+              type: string
+      links:
+        type: array
+        items:
+          type: object
+          properties:
+            concept_id:
+              type: integer
+            concept_name:
+              type: string
+            concept_status:
+              type: string
+            is_times_tag:
+              type: integer
+            concept_type:
+              type: string
+            link_id:
+              type: integer
+            relation:
+              type: string
+            link:
+              type: string
+            link_type:
+              type: string
+            mapping_type:
+              type: string
+      search_api_query:
+        type: string
+      article_list:
+        type: object
+        properties:
+          results:
+            type: array
+            items:
+              type: object
+              properties:
+                body:
+                  type: string
+                byline:
+                  type: string
+                concepts:
+                  type: object
+                  properties:
+                    nytd_des:
+                      type: array
+                      items:
+                        type: string
+                    nytd_org:
+                      type: array
+                      items:
+                        type: string
+                    nytd_per:
+                      type: array
+                      items:
+                        type: string
+                date:
+                  type: string
+                document_type:
+                  type: string
+                title:
+                  type: string
+                type_of_material:
+                  type: string
+                url:
+                  type: string
+          total:
+            type: integer
+      scope_notes:
+        type: array
+        items:
+          type: object
+          properties:
+            scope_note:
+              type: string
+            scope_note_name:
+              type: string
+            scope_note_type:
+              type: string
+      combinations:
+        type: array
+        items:
+          type: object
+          properties:
+            combination_source_concept_id:
+              type: integer
+            combination_source_concept_name:
+              type: string
+            combination_source_concept_type:
+              type: string
+            combination_target_concept_id:
+              type: integer
+            combination_target_concept_name:
+              type: string
+            combination_target_concept_type:
+              type: string
+            combination_note:
+              type: string
+      ancestors:
+        type: array
+        items:
+          $ref: '#/definitions/ConceptRelation'
+      descendants:
+        type: array
+        items:
+          $ref: '#/definitions/ConceptRelation'
+  ConceptRelation:
+    type: object
+    properties:
+      concept_id:
+        type: integer
+      concept_name:
+        type: string
+      is_times_tag:
+        type: integer
+      concept_status:
+        type: string
+      vernacular:
+        type: string
+      concept_type:
+        type: string
+      concept_created:
+        type: string
+      concept_updated:
+        $ref: '#/definitions/TestStringRef'
+      class:
+        type: string
+        enum:
+          - nytd_geo
+          - nytd_per
+          - nytd_org
+          - nytd_des
+  TestStringRef:
+    type: string
+    minLength: 3
+  TestModel:
+    type: object
+    properties:
+      category:
+        type: string
+        enum:
+          - nytd_geo
+          - nytd_per
+          - nytd_org
+          - nytd_des
+        x-proto-tag: 1
+      class:
+        type: array
+        items:
+          type: object
+          properties:
+            something:
+              type: string
+        x-proto-tag: 2
+      test_bool:
+        type: boolean
+        x-proto-tag: 3
+      test_bool_value:
+        type:
+          - 'null'
+          - boolean
+        x-proto-tag: 4
+      test_num_value:
+        type:
+          - 'null'
+          - number
+        format: double
+        x-proto-tag: 5
+      test_numer_value:
+        type:
+          - 'null'
+          - number
+        x-proto-tag: 6
+      test_float_value:
+        type:
+          - 'null'
+          - float
+        x-proto-tag: 7
+      test_string_value:
+        type:
+          - 'null'
+          - string
+        x-proto-tag: 8
+      test_bytes_value:
+        type:
+          - 'null'
+          - bytes
+        x-proto-tag: 9
+      test_any_value:
+        type:
+          - 'null'
+          - string
+          - object
+        x-proto-tag: 10
+      test_map_object:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/TestModel'
+        x-proto-tag: 11
+      test_map_scalar:
+        type: object
+        additionalProperties:
+          type: string
+        x-proto-tag: 12
+securityDefinitions:
+  apikey:
+    type: apiKey
+    name: api-key
+    in: query

--- a/openapi.go
+++ b/openapi.go
@@ -339,7 +339,7 @@ func protoComplex(i *Items, typ, msgName, name string, defs map[string]*Items, i
 	switch typ {
 	case "object":
 		// make a map of the additional props we might get
-		addlProps := make(map[string]string)
+		addlProps := map[string]string{}
 
 		// check for map declaration
 		switch addl := i.AdditionalProperties.(type) {

--- a/proto_test.go
+++ b/proto_test.go
@@ -12,6 +12,109 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+func TestRefType(t *testing.T) {
+	tests := []struct {
+		tName string
+		ref   string
+		defs  map[string]*Items
+
+		want    string
+		wantPkg string
+	}{
+		{
+			"Simple ref",
+
+			"#/definitions/Name",
+			map[string]*Items{
+				"Name": &Items{
+					Type: "object",
+				},
+			},
+			"Name",
+			"",
+		},
+		{
+			"URL nested ref",
+
+			"http://something.com/commons/name.json#/definitions/Name",
+			nil,
+			"commons.name.Name",
+			"commons/name.proto",
+		},
+		{
+			"URL no ref",
+
+			"http://something.com/commons/name.json",
+			nil,
+			"commons.Name",
+			"commons/name.proto",
+		},
+		{
+			"relative no ref",
+
+			"commons/names/Name.json",
+			nil,
+			"commons.names.Name",
+			"commons/names/name.proto",
+		},
+		{
+			"relative nested ref",
+
+			"commons/names/Name.json#/definitions/Name",
+			nil,
+			"commons.names.name.Name",
+			"commons/names/name.proto",
+		},
+		{
+			"relative nested ref",
+
+			"something.json#/definitions/RelativeRef",
+			nil,
+			"something.RelativeRef",
+			"something.proto",
+		},
+
+		{
+			"relative nested ref",
+
+			"names.json#/definitions/Name",
+			nil,
+			"names.Name",
+			"names.proto",
+		},
+
+		{
+			"relative ref, back one dir",
+
+			"../commons/names/Name.json",
+			nil,
+			"commons.names.Name",
+			"commons/names/name.proto",
+		},
+		{
+			"relative nested ref, back two dir",
+
+			"../../commons/names/Name.json#/definitions/Name",
+			nil,
+			"commons.names.name.Name",
+			"commons/names/name.proto",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.tName, func(t *testing.T) {
+			got, gotPkg := refType(test.ref, test.defs)
+			if got != test.want {
+				t.Errorf("[%s] expected %q got %q", test.tName, test.want, got)
+			}
+
+			if gotPkg != test.wantPkg {
+				t.Errorf("[%s] expected package %q got %q", test.tName, test.wantPkg, gotPkg)
+			}
+		})
+	}
+}
+
 func TestGenerateProto(t *testing.T) {
 	tests := []struct {
 		yaml             bool
@@ -178,6 +281,7 @@ func TestGenerateProto(t *testing.T) {
 					t.Fatalf("unable to unmarshal text fixture into APIDefinition: %s - %s",
 						test.givenFixturePath, err)
 				}
+
 			}
 
 			protoResult, err := GenerateProto(&testAPI, test.options)
@@ -194,7 +298,7 @@ func TestGenerateProto(t *testing.T) {
 			if string(want) != string(protoResult) {
 				dmp := diffmatchpatch.New()
 				diffs := dmp.DiffMain(string(want), string(protoResult), false)
-				t.Errorf("test (%s) differences:\n%s",
+				t.Errorf("testYaml (%s) differences:\n%s",
 					test.givenFixturePath, dmp.DiffPrettyText(diffs))
 			}
 		})


### PR DESCRIPTION
This fixes a problem when generating protos from `yaml`. Take the following example:
```yaml
swagger: '2.0'
info:
  title: refs
definitions:
  TestModel:
    type: object
    properties:
      test_map_object:
        type: object
        additionalProperties:
          $ref: '#/definitions/TestModel'
        x-proto-tag: 11
      test_map_scalar:
        type: object
        additionalProperties:
          type: string
        x-proto-tag: 12
```

We'd expect to generate the following (which it does if the swagger file is in `json`:
```proto
syntax = "proto3";

package refs;

message TestModel {
    map<string, TestModel> test_map_object = 11;
    map<string, string> test_map_scalar = 12;
}
```

But it actually produces something very different:
```
--- PASS: TestGenerateProto/fixtures/refs.json (0.00s)
--- FAIL: TestGenerateProto/fixtures/refs.yaml (0.00s)
        proto_test.go:197: test (fixtures/refs.yaml) differences:
                syntax = "proto3";

                package refs;

                message TestModel {
                    messap<ge Testring,_map_object {
                    }
                    TestM_map_odbjel>ct test_map_object = 11;
                    messap<ge Test_map_scalaring, {
                    }
                    Test_map_scalaring> test_map_scalar = 12;
                }
```

This PR addresses this and also adds tests around it.