### PR TITLE
Implement x-global-options

### DIFF
--- a/fixtures/global_options.proto
+++ b/fixtures/global_options.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package globaloptions;
+
+import "google/protobuf/empty.proto";
+
+option go_package = "myawesomepackage";
+
+
+
+
+
+service GlobalOptionsService {
+    rpc GetFoo(google.protobuf.Empty) returns (google.protobuf.Empty) {}
+}

--- a/fixtures/global_options.yaml
+++ b/fixtures/global_options.yaml
@@ -1,0 +1,16 @@
+swagger: '2.0'
+  
+info:
+  version: "0.0.0"
+  title: Global options
+  description: Produce global gRPC options
+
+x-global-options:
+  go_package: myawesomepackage
+
+paths:
+  /foo:
+    get:
+      200:
+        schema:
+          type: string

--- a/fixtures/integers.proto
+++ b/fixtures/integers.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-import "google/protobuf/empty.proto";
-
 package integers;
+
+import "google/protobuf/empty.proto";
 
 message Integers {
     int32 intValue = 1;

--- a/openapi.go
+++ b/openapi.go
@@ -21,13 +21,14 @@ type APIDefinition struct {
 		Description string `yaml:"description" json:"description"`
 		Version     string `yaml:"version" json:"version"`
 	} `yaml:"info" json:"info"`
-	Host        string            `yaml:"host" json:"host"`
-	Schemes     []string          `yaml:"schemes" json:"schemes"`
-	BasePath    string            `yaml:"basePath" json:"basePath"`
-	Produces    []string          `yaml:"produces" json:"produces"`
-	Paths       map[string]*Path  `yaml:"paths" json:"paths"`
-	Definitions map[string]*Items `yaml:"definitions" json:"definitions"`
-	Parameters  map[string]*Items `yaml:"parameters" json:"parameters"`
+	Host          string            `yaml:"host" json:"host"`
+	Schemes       []string          `yaml:"schemes" json:"schemes"`
+	BasePath      string            `yaml:"basePath" json:"basePath"`
+	Produces      []string          `yaml:"produces" json:"produces"`
+	Paths         map[string]*Path  `yaml:"paths" json:"paths"`
+	Definitions   map[string]*Items `yaml:"definitions" json:"definitions"`
+	Parameters    map[string]*Items `yaml:"parameters" json:"parameters"`
+	GlobalOptions map[string]string `yaml:"x-global-options" json:"x-global-options"`
 }
 
 // Path represents all of the endpoints and parameters available for a single

--- a/proto_test.go
+++ b/proto_test.go
@@ -123,7 +123,6 @@ type genProtoTestCase struct {
 	remoteFiles      []string
 }
 
-
 func testGenProto(t *testing.T, tests ...genProtoTestCase) {
 	t.Helper()
 	origin, _ := os.Getwd()
@@ -284,6 +283,10 @@ func TestGenerateProto(t *testing.T) {
 		{
 			givenFixturePath: "fixtures/integers.yaml",
 			wantProto:        "fixtures/integers.proto",
+		},
+		{
+			givenFixturePath: "fixtures/global_options.yaml",
+			wantProto:        "fixtures/global_options.proto",
 		},
 	}
 	testGenProto(t, tests...)

--- a/proto_test.go
+++ b/proto_test.go
@@ -281,6 +281,10 @@ func TestGenerateProto(t *testing.T) {
 			givenFixturePath: "fixtures/semantic_api.yaml",
 			wantProto:        "fixtures/semantic_api.proto",
 		},
+		{
+			givenFixturePath: "fixtures/integers.yaml",
+			wantProto:        "fixtures/integers.proto",
+		},
 	}
 	testGenProto(t, tests...)
 }

--- a/proto_test.go
+++ b/proto_test.go
@@ -171,10 +171,16 @@ func testGenProto(t *testing.T, tests ...genProtoTestCase) {
 			}
 
 			if string(want) != string(protoResult) {
-				dmp := diffmatchpatch.New()
-				diffs := dmp.DiffMain(string(want), string(protoResult), false)
+				diff := difflib.UnifiedDiff{
+					A:        difflib.SplitLines(string(want)),
+					B:        difflib.SplitLines(string(protoResult)),
+					FromFile: test.wantProto,
+					ToFile:   "Generated",
+					Context:  3,
+				}
+				text, _ := difflib.GetUnifiedDiffString(diff)
 				t.Errorf("testYaml (%s) differences:\n%s",
-					test.givenFixturePath, dmp.DiffPrettyText(diffs))
+					test.givenFixturePath, text)
 			}
 		})
 	}

--- a/proto_test.go
+++ b/proto_test.go
@@ -3,8 +3,10 @@ package openapi2proto
 import (
 	"encoding/json"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/sergi/go-diff/diffmatchpatch"
@@ -115,152 +117,26 @@ func TestRefType(t *testing.T) {
 	}
 }
 
-func TestGenerateProto(t *testing.T) {
-	tests := []struct {
-		yaml             bool
-		options          bool
-		givenFixturePath string
+type genProtoTestCase struct {
+	options          bool
+	givenFixturePath string
+	wantProto        string
+	remoteFiles      []string
+}
 
-		wantProto string
-	}{
-		{
-			true,
-			false,
-			"fixtures/cats.yaml",
-
-			"fixtures/cats.proto",
-		},
-		{
-			true,
-			false,
-			"fixtures/catsanddogs.yaml",
-
-			"fixtures/catsanddogs.proto",
-		},
-		{
-			false,
-			false,
-			"fixtures/semantic_api.json",
-
-			"fixtures/semantic_api.proto",
-		},
-		{
-			false,
-			false,
-			"fixtures/most_popular.json",
-
-			"fixtures/most_popular.proto",
-		},
-		{
-			true,
-			false,
-			"fixtures/spec.yaml",
-
-			"fixtures/spec.proto",
-		},
-		{
-			false,
-			false,
-			"fixtures/spec.json",
-
-			"fixtures/spec.proto",
-		},
-		{
-			false,
-			true,
-			"fixtures/semantic_api.json",
-
-			"fixtures/semantic_api-options.proto",
-		},
-		{
-			false,
-			true,
-			"fixtures/most_popular.json",
-
-			"fixtures/most_popular-options.proto",
-		},
-		{
-			true,
-			true,
-			"fixtures/spec.yaml",
-
-			"fixtures/spec-options.proto",
-		},
-		{
-			false,
-			true,
-			"fixtures/spec.json",
-
-			"fixtures/spec-options.proto",
-		},
-		{
-			false,
-			false,
-			"fixtures/includes_query.json",
-
-			"fixtures/includes_query.proto",
-		},
-		{
-			false,
-			false,
-			"fixtures/lowercase_def.json",
-
-			"fixtures/lowercase_def.proto",
-		},
-		{
-			true,
-			false,
-			"fixtures/petstore/swagger.yaml",
-
-			"fixtures/petstore/swagger.proto",
-		},
-		{
-			false,
-			false,
-			"fixtures/missing_type.json",
-
-			"fixtures/missing_type.proto",
-		},
-		{
-			false,
-			false,
-			"fixtures/kubernetes.json",
-
-			"fixtures/kubernetes.proto",
-		},
-		{
-			false,
-			false,
-			"fixtures/accountv1-0.json",
-
-			"fixtures/accountv1-0.proto",
-		},
-		{
-			false,
-			false,
-			"fixtures/refs.json",
-
-			"fixtures/refs.proto",
-		},
-		{
-			true,
-			false,
-			"fixtures/refs.yaml",
-
-			"fixtures/refs.proto",
-		},
-		{
-			true,
-			false,
-			"fixtures/semantic_api.yaml",
-
-			"fixtures/semantic_api.proto",
-		},
-	}
+func testGenProto(t *testing.T, tests ...genProtoTestCase) {
+	t.Helper()
 
 	origin, _ := os.Getwd()
 	for _, test := range tests {
 		t.Run(test.givenFixturePath, func(t *testing.T) {
+			for _, remoteFile := range test.remoteFiles {
+				res, err := http.Get(remoteFile)
+				if err != nil || res.StatusCode != http.StatusOK {
+					t.Skip(`Remote file ` + remoteFile + ` is not available`)
+				}
+			}
+
 			os.Chdir(origin)
 			testSpec, err := ioutil.ReadFile(test.givenFixturePath)
 			if err != nil {
@@ -269,7 +145,7 @@ func TestGenerateProto(t *testing.T) {
 
 			os.Chdir(path.Dir(test.givenFixturePath))
 			var testAPI APIDefinition
-			if test.yaml {
+			if strings.HasSuffix(test.givenFixturePath, ".yaml") {
 				err = yaml.Unmarshal(testSpec, &testAPI)
 				if err != nil {
 					t.Fatalf("unable to unmarshal text fixture into APIDefinition: %s - %s ",
@@ -303,4 +179,103 @@ func TestGenerateProto(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNetwork(t *testing.T) {
+	testGenProto(t, genProtoTestCase{
+		givenFixturePath: "fixtures/petstore/swagger.yaml",
+		wantProto:        "fixtures/petstore/swagger.proto",
+		remoteFiles: []string{
+			"https://raw.githubusercontent.com/NYTimes/openapi2proto/master/fixtures/petstore/Pet.yaml",
+		},
+	})
+}
+
+func TestGenerateProto(t *testing.T) {
+	tests := []genProtoTestCase{
+		{
+			givenFixturePath: "fixtures/cats.yaml",
+			wantProto:        "fixtures/cats.proto",
+		},
+		{
+			givenFixturePath: "fixtures/catsanddogs.yaml",
+
+			wantProto: "fixtures/catsanddogs.proto",
+		},
+		{
+			givenFixturePath: "fixtures/semantic_api.json",
+			wantProto:        "fixtures/semantic_api.proto",
+		},
+		{
+			givenFixturePath: "fixtures/most_popular.json",
+			wantProto:        "fixtures/most_popular.proto",
+		},
+		{
+			givenFixturePath: "fixtures/spec.yaml",
+			wantProto:        "fixtures/spec.proto",
+		},
+		{
+			givenFixturePath: "fixtures/spec.json",
+			wantProto:        "fixtures/spec.proto",
+		},
+		{
+			options:          true,
+			givenFixturePath: "fixtures/semantic_api.json",
+			wantProto:        "fixtures/semantic_api-options.proto",
+		},
+		{
+			options:          true,
+			givenFixturePath: "fixtures/most_popular.json",
+			wantProto:        "fixtures/most_popular-options.proto",
+		},
+		{
+			options:          true,
+			givenFixturePath: "fixtures/spec.yaml",
+			wantProto:        "fixtures/spec-options.proto",
+		},
+		{
+			options:          true,
+			givenFixturePath: "fixtures/spec.json",
+			wantProto:        "fixtures/spec-options.proto",
+		},
+		{
+			givenFixturePath: "fixtures/includes_query.json",
+			wantProto:        "fixtures/includes_query.proto",
+		},
+		{
+
+			givenFixturePath: "fixtures/lowercase_def.json",
+			wantProto:        "fixtures/lowercase_def.proto",
+		},
+		{
+
+			givenFixturePath: "fixtures/missing_type.json",
+			wantProto:        "fixtures/missing_type.proto",
+		},
+		{
+
+			givenFixturePath: "fixtures/kubernetes.json",
+			wantProto:        "fixtures/kubernetes.proto",
+		},
+		{
+
+			givenFixturePath: "fixtures/accountv1-0.json",
+			wantProto:        "fixtures/accountv1-0.proto",
+		},
+		{
+
+			givenFixturePath: "fixtures/refs.json",
+			wantProto:        "fixtures/refs.proto",
+		},
+		{
+
+			givenFixturePath: "fixtures/refs.yaml",
+			wantProto:        "fixtures/refs.proto",
+		},
+		{
+			givenFixturePath: "fixtures/semantic_api.yaml",
+			wantProto:        "fixtures/semantic_api.proto",
+		},
+	}
+	testGenProto(t, tests...)
 }

--- a/proto_test.go.orig
+++ b/proto_test.go.orig
@@ -1,0 +1,306 @@
+package openapi2proto
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/sergi/go-diff/diffmatchpatch"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestRefType(t *testing.T) {
+	tests := []struct {
+		tName string
+		ref   string
+		defs  map[string]*Items
+
+		want    string
+		wantPkg string
+	}{
+		{
+			"Simple ref",
+
+			"#/definitions/Name",
+			map[string]*Items{
+				"Name": &Items{
+					Type: "object",
+				},
+			},
+			"Name",
+			"",
+		},
+		{
+			"URL nested ref",
+
+			"http://something.com/commons/name.json#/definitions/Name",
+			nil,
+			"commons.name.Name",
+			"commons/name.proto",
+		},
+		{
+			"URL no ref",
+
+			"http://something.com/commons/name.json",
+			nil,
+			"commons.Name",
+			"commons/name.proto",
+		},
+		{
+			"relative no ref",
+
+			"commons/names/Name.json",
+			nil,
+			"commons.names.Name",
+			"commons/names/name.proto",
+		},
+		{
+			"relative nested ref",
+
+			"commons/names/Name.json#/definitions/Name",
+			nil,
+			"commons.names.name.Name",
+			"commons/names/name.proto",
+		},
+		{
+			"relative nested ref",
+
+			"something.json#/definitions/RelativeRef",
+			nil,
+			"something.RelativeRef",
+			"something.proto",
+		},
+
+		{
+			"relative nested ref",
+
+			"names.json#/definitions/Name",
+			nil,
+			"names.Name",
+			"names.proto",
+		},
+
+		{
+			"relative ref, back one dir",
+
+			"../commons/names/Name.json",
+			nil,
+			"commons.names.Name",
+			"commons/names/name.proto",
+		},
+		{
+			"relative nested ref, back two dir",
+
+			"../../commons/names/Name.json#/definitions/Name",
+			nil,
+			"commons.names.name.Name",
+			"commons/names/name.proto",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.tName, func(t *testing.T) {
+			got, gotPkg := refType(test.ref, test.defs)
+			if got != test.want {
+				t.Errorf("[%s] expected %q got %q", test.tName, test.want, got)
+			}
+
+			if gotPkg != test.wantPkg {
+				t.Errorf("[%s] expected package %q got %q", test.tName, test.wantPkg, gotPkg)
+			}
+		})
+	}
+}
+
+func TestGenerateProto(t *testing.T) {
+	tests := []struct {
+		yaml             bool
+		options          bool
+		givenFixturePath string
+
+		wantProto string
+	}{
+		{
+			true,
+			false,
+			"fixtures/cats.yaml",
+
+			"fixtures/cats.proto",
+		},
+		{
+			true,
+			false,
+			"fixtures/catsanddogs.yaml",
+
+			"fixtures/catsanddogs.proto",
+		},
+		{
+			false,
+			false,
+			"fixtures/semantic_api.json",
+
+			"fixtures/semantic_api.proto",
+		},
+		{
+			false,
+			false,
+			"fixtures/most_popular.json",
+
+			"fixtures/most_popular.proto",
+		},
+		{
+			true,
+			false,
+			"fixtures/spec.yaml",
+
+			"fixtures/spec.proto",
+		},
+		{
+			false,
+			false,
+			"fixtures/spec.json",
+
+			"fixtures/spec.proto",
+		},
+		{
+			false,
+			true,
+			"fixtures/semantic_api.json",
+
+			"fixtures/semantic_api-options.proto",
+		},
+		{
+			false,
+			true,
+			"fixtures/most_popular.json",
+
+			"fixtures/most_popular-options.proto",
+		},
+		{
+			true,
+			true,
+			"fixtures/spec.yaml",
+
+			"fixtures/spec-options.proto",
+		},
+		{
+			false,
+			true,
+			"fixtures/spec.json",
+
+			"fixtures/spec-options.proto",
+		},
+		{
+			false,
+			false,
+			"fixtures/includes_query.json",
+
+			"fixtures/includes_query.proto",
+		},
+		{
+			false,
+			false,
+			"fixtures/lowercase_def.json",
+
+			"fixtures/lowercase_def.proto",
+		},
+		{
+			true,
+			false,
+			"fixtures/petstore/swagger.yaml",
+
+			"fixtures/petstore/swagger.proto",
+		},
+		{
+			false,
+			false,
+			"fixtures/missing_type.json",
+
+			"fixtures/missing_type.proto",
+		},
+		{
+			false,
+			false,
+			"fixtures/kubernetes.json",
+
+			"fixtures/kubernetes.proto",
+		},
+		{
+			false,
+			false,
+			"fixtures/accountv1-0.json",
+
+			"fixtures/accountv1-0.proto",
+		},
+		{
+			false,
+			false,
+			"fixtures/refs.json",
+
+			"fixtures/refs.proto",
+		},
+		{
+			true,
+			false,
+			"fixtures/refs.yaml",
+
+			"fixtures/refs.proto",
+		},
+		{
+			true,
+			false,
+			"fixtures/semantic_api.yaml",
+
+			"fixtures/semantic_api.proto",
+		},
+	}
+
+	origin, _ := os.Getwd()
+	for _, test := range tests {
+		t.Run(test.givenFixturePath, func(t *testing.T) {
+			os.Chdir(origin)
+			testSpec, err := ioutil.ReadFile(test.givenFixturePath)
+			if err != nil {
+				t.Fatal("unable to open test fixture: ", err)
+			}
+
+			os.Chdir(path.Dir(test.givenFixturePath))
+			var testAPI APIDefinition
+			if test.yaml {
+				err = yaml.Unmarshal(testSpec, &testAPI)
+				if err != nil {
+					t.Fatalf("unable to unmarshal text fixture into APIDefinition: %s - %s ",
+						test.givenFixturePath, err)
+				}
+			} else {
+				err = json.Unmarshal(testSpec, &testAPI)
+				if err != nil {
+					t.Fatalf("unable to unmarshal text fixture into APIDefinition: %s - %s",
+						test.givenFixturePath, err)
+				}
+
+			}
+
+			protoResult, err := GenerateProto(&testAPI, test.options)
+			if err != nil {
+				t.Fatal("unable to generate protobuf from APIDefinition: ", err)
+			}
+
+			os.Chdir(origin)
+			want, err := ioutil.ReadFile(test.wantProto)
+			if err != nil {
+				t.Fatal("unable to open test fixture: ", err)
+			}
+
+			if string(want) != string(protoResult) {
+				dmp := diffmatchpatch.New()
+				diffs := dmp.DiffMain(string(want), string(protoResult), false)
+				t.Errorf("testYaml (%s) differences:\n%s",
+					test.givenFixturePath, dmp.DiffPrettyText(diffs))
+			}
+		})
+	}
+}


### PR DESCRIPTION
fixes #64 

Accepts `x-global-options`, which generates the appropriate `option X = Y;` declarations in the proto file