### PR TITLE
Use pmezard/go-difflib

### DIFF
--- a/proto_test.go
+++ b/proto_test.go
@@ -7,8 +7,7 @@ import (
 	"path"
 	"testing"
 
-	"github.com/sergi/go-diff/diffmatchpatch"
-
+	"github.com/pmezard/go-difflib/difflib"
 	"gopkg.in/yaml.v2"
 )
 
@@ -296,10 +295,16 @@ func TestGenerateProto(t *testing.T) {
 			}
 
 			if string(want) != string(protoResult) {
-				dmp := diffmatchpatch.New()
-				diffs := dmp.DiffMain(string(want), string(protoResult), false)
+				diff := difflib.UnifiedDiff{
+					A:        difflib.SplitLines(string(want)),
+					B:        difflib.SplitLines(string(protoResult)),
+					FromFile: test.wantProto,
+					ToFile:   "Generated",
+					Context:  3,
+				}
+				text, _ := difflib.GetUnifiedDiffString(diff)
 				t.Errorf("testYaml (%s) differences:\n%s",
-					test.givenFixturePath, dmp.DiffPrettyText(diffs))
+					test.givenFixturePath, text)
 			}
 		})
 	}


### PR DESCRIPTION
Replace diff library used in tests. This has at least one major advantage over the old diff, in that it gives you *context* diffs, and not the entire dump with colors (which is extremely hard to read when you have to scroll all the way back)

fixes #67