### PR TITLE
Cleanup code

### DIFF
--- a/openapi.go
+++ b/openapi.go
@@ -331,7 +331,7 @@ func protoComplex(dst io.Writer, i *Items, typ, msgName, name string, defs map[s
 		// check for referenced schema object (parameters/fields)
 		if i.Schema != nil {
 			if i.Schema.Ref != "" {
-				refDef(dst, indent(depth+1)+name, i.Schema.Ref, *index, defs)
+				refDef(dst, name, i.Schema.Ref, *index, defs)
 				return
 			}
 		}

--- a/openapi.go
+++ b/openapi.go
@@ -809,7 +809,3 @@ func format(fmt interface{}) string {
 	return format
 
 }
-
-func cleanAndTitle(s string) string {
-	return cleanCharacters(strings.Title(s))
-}

--- a/openapi.go
+++ b/openapi.go
@@ -430,12 +430,9 @@ func ProtoEnum(name string, enums []string, depth int) string {
 
 	var b bytes.Buffer
 
-	c := zcounter()
-
 	fmt.Fprintf(&b, "enum %s {", name)
-	for _, enum := range enums {
-		*c++
-		fmt.Fprintf(&b, "\n%s%s = %d;", indentStr, toEnum(name, enum, depth), *c)
+	for i, enum := range enums {
+		fmt.Fprintf(&b, "\n%s%s = %d;", indentStr, toEnum(name, enum, depth), i)
 	}
 	fmt.Fprintf(&b, "\n}")
 	return b.String()

--- a/openapi.go
+++ b/openapi.go
@@ -764,8 +764,7 @@ func messageProtobuf(dst io.Writer, m *Model, defs map[string]*Items) {
 	sort.Strings(propNames)
 
 	var b bytes.Buffer
-	c := counter()
-
+	var counter int
 	var buf bytes.Buffer // holds the contents within message %s {...}
 	for i, pname := range propNames {
 		prop := m.Properties[pname]
@@ -779,7 +778,7 @@ func messageProtobuf(dst io.Writer, m *Model, defs map[string]*Items) {
 		}
 
 		fmt.Fprintf(&buf, "\n")
-		prop.ProtoMessage(&buf, m.Name, pname, defs, c, m.Depth)
+		prop.ProtoMessage(&buf, m.Name, pname, defs, &counter, m.Depth)
 		fmt.Fprintf(&buf, ";")
 	}
 

--- a/option.go
+++ b/option.go
@@ -25,14 +25,6 @@ func (a HTTPAnnotation) Protobuf(indent string) string {
 	return buf.String()
 }
 
-func isNumericType(s string) bool {
-	switch s {
-	case "int32", "int64", "double", "float", "uint32", "uint64", "sint32", "sint64", "fixed32", "fixed64", "sfixed32", "sfixed64":
-		return true
-	}
-	return false
-}
-
 func (e Extension) Protobuf(indent string) string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "extend %s {", e.Base)

--- a/proto.go
+++ b/proto.go
@@ -466,9 +466,20 @@ func toEnum(name, enum string, depth int) string {
 }
 
 func cleanCharacters(input string) string {
-	re := regexp.MustCompile(`[^a-zA-Z0-9]+`)
-	output := re.ReplaceAllString(input, "_")
-	return output
+	var buf bytes.Buffer
+	for _, r := range input {
+		// anything other than a-z, A-Z, 0-9 should be converted
+		// to an underscore
+		switch {
+		case r >= 0x41 && r <= 0x5a: // A-Z
+		case r >= 0x61 && r <= 0x7a: // a-z
+		case r >= 0x30 && r <= 0x39: // 0-9
+		default:
+			r = '_'
+		}
+		buf.WriteRune(r)
+	}
+	return buf.String()
 }
 
 func cleanSpacing(output []byte) []byte {

--- a/proto.go
+++ b/proto.go
@@ -195,8 +195,9 @@ func GenerateProto(api *APIDefinition, annotate bool) ([]byte, error) {
 	}
 
 	for _, modelName := range sortedModels {
+		var counter int
 		model := api.Definitions[modelName]
-		model.ProtoMessage(&body, "", modelName, api.Definitions, counter(), -1)
+		model.ProtoMessage(&body, "", modelName, api.Definitions, &counter, -1)
 	}
 
 	if len(api.Extensions) > 0 {
@@ -424,11 +425,6 @@ func serviceName(t string) string {
 		name += strings.Title(nme)
 	}
 	return cleanCharacters(name) + "Service"
-}
-
-func counter() *int {
-	i := 0
-	return &i
 }
 
 func toEnum(name, enum string, depth int) string {

--- a/proto.go
+++ b/proto.go
@@ -435,14 +435,6 @@ func zcounter() *int {
 	return &i
 }
 
-func indent(depth int) string {
-	var out string
-	for i := 0; i < depth; i++ {
-		out += "    "
-	}
-	return out
-}
-
 func toEnum(name, enum string, depth int) string {
 	if strings.TrimSpace(enum) == "" {
 		enum = "empty"

--- a/proto.go
+++ b/proto.go
@@ -430,10 +430,6 @@ func counter() *int {
 	i := 0
 	return &i
 }
-func zcounter() *int {
-	i := -1
-	return &i
-}
 
 func toEnum(name, enum string, depth int) string {
 	if strings.TrimSpace(enum) == "" {

--- a/proto.go
+++ b/proto.go
@@ -415,18 +415,6 @@ func traverseItemsForImports(item *Items, defs map[string]*Items) []string {
 	return out
 }
 
-func packageName(t string) string {
-	return cleanCharacters(strings.ToLower(strings.Join(strings.Fields(t), "")))
-}
-
-func serviceName(t string) string {
-	var name string
-	for _, nme := range strings.Fields(t) {
-		name += strings.Title(nme)
-	}
-	return cleanCharacters(name) + "Service"
-}
-
 func toEnum(name, enum string, depth int) string {
 	if strings.TrimSpace(enum) == "" {
 		enum = "empty"
@@ -459,34 +447,6 @@ func toEnum(name, enum string, depth int) string {
 	}
 
 	return out.String()
-}
-
-func cleanCharacters(input string) string {
-	var buf bytes.Buffer
-	for _, r := range input {
-		// anything other than a-z, A-Z, 0-9 should be converted
-		// to an underscore
-		switch {
-		case r >= 0x41 && r <= 0x5a: // A-Z
-		case r >= 0x61 && r <= 0x7a: // a-z
-		case r >= 0x30 && r <= 0x39: // 0-9
-		default:
-			r = '_'
-		}
-		buf.WriteRune(r)
-	}
-	return buf.String()
-}
-
-func cleanSpacing(output []byte) []byte {
-	re := regexp.MustCompile(`}\n*message `)
-	output = re.ReplaceAll(output, []byte("}\n\nmessage "))
-	re = regexp.MustCompile(`}\n*enum `)
-	output = re.ReplaceAll(output, []byte("}\n\nenum "))
-	re = regexp.MustCompile(`;\n*message `)
-	output = re.ReplaceAll(output, []byte(";\n\nmessage "))
-	re = regexp.MustCompile(`}\n*service `)
-	return re.ReplaceAll(output, []byte("}\n\nservice "))
 }
 
 var knownImports = map[string]string{

--- a/proto.go
+++ b/proto.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"

--- a/proto.go
+++ b/proto.go
@@ -435,11 +435,6 @@ func zcounter() *int {
 	return &i
 }
 
-func inc(i *int) int {
-	*i++
-	return *i
-}
-
 func indent(depth int) string {
 	var out string
 	for i := 0; i < depth; i++ {

--- a/strings.go
+++ b/strings.go
@@ -1,0 +1,67 @@
+package openapi2proto
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+func cleanSpacing(output []byte) []byte {
+	re := regexp.MustCompile(`}\n*message `)
+	output = re.ReplaceAll(output, []byte("}\n\nmessage "))
+	re = regexp.MustCompile(`}\n*enum `)
+	output = re.ReplaceAll(output, []byte("}\n\nenum "))
+	re = regexp.MustCompile(`;\n*message `)
+	output = re.ReplaceAll(output, []byte(";\n\nmessage "))
+	re = regexp.MustCompile(`}\n*service `)
+	return re.ReplaceAll(output, []byte("}\n\nservice "))
+}
+
+// takes strings like "foo bar baz" and turns it into "foobarbaz"
+// if title is true, then "FooBarBaz"
+func concatSpaces(s string, title bool) string {
+	var buf bytes.Buffer
+	var wasSpace bool
+	for _, r := range s {
+		if unicode.IsSpace(r) {
+			wasSpace = true
+			continue
+		}
+		if wasSpace && title {
+			r = unicode.ToUpper(r)
+		}
+		buf.WriteRune(r)
+		wasSpace = false
+	}
+	return buf.String()
+}
+
+func cleanAndTitle(s string) string {
+	return cleanCharacters(strings.Title(s))
+}
+
+func packageName(s string) string {
+	return cleanCharacters(strings.ToLower(concatSpaces(s, false)))
+}
+
+func serviceName(s string) string {
+	return cleanCharacters(concatSpaces(s, true) + "Service")
+}
+
+func cleanCharacters(input string) string {
+	var buf bytes.Buffer
+	for _, r := range input {
+		// anything other than a-z, A-Z, 0-9 should be converted
+		// to an underscore
+		switch {
+		case r >= 0x41 && r <= 0x5a: // A-Z
+		case r >= 0x61 && r <= 0x7a: // a-z
+		case r >= 0x30 && r <= 0x39: // 0-9
+		default:
+			r = '_'
+		}
+		buf.WriteRune(r)
+	}
+	return buf.String()
+}


### PR DESCRIPTION
Some low-hanging fruits.

* Remove unused methods `inc` and `isNumericType`
* Remove `indent`
* Remove `zcounter`
* Remove `counter`
* Reimplement `cleanCharacters`  without the use of regular expressions
* Move string utilities to their own file (git commit message says "package", but I meant "file")
* Break up `protoComplex`