### PR TITLE
Support minimum/maximum attributes

### DIFF
--- a/openapi/interface.go
+++ b/openapi/interface.go
@@ -38,15 +38,15 @@ type Spec struct {
 		Description string `yaml:"description" json:"description"`
 		Version     string `yaml:"version" json:"version"`
 	} `yaml:"info" json:"info"`
-	Host               string                `yaml:"host" json:"host"`
-	Schemes            []string              `yaml:"schemes" json:"schemes"`
-	BasePath           string                `yaml:"basePath" json:"basePath"`
-	Produces           []string              `yaml:"produces" json:"produces"`
-	Paths              map[string]*Path      `yaml:"paths" json:"paths"`
-	Definitions        map[string]*Schema    `yaml:"definitions" json:"definitions"`
-	Parameters         map[string]*Parameter `yaml:"parameters" json:"parameters"`
-	Extensions         []*Extension          `yaml:"x-extensions" json:"x-extensions"`
-	GlobalOptions      GlobalOptions         `yaml:"x-global-options" json:"x-global-options"`
+	Host          string                `yaml:"host" json:"host"`
+	Schemes       []string              `yaml:"schemes" json:"schemes"`
+	BasePath      string                `yaml:"basePath" json:"basePath"`
+	Produces      []string              `yaml:"produces" json:"produces"`
+	Paths         map[string]*Path      `yaml:"paths" json:"paths"`
+	Definitions   map[string]*Schema    `yaml:"definitions" json:"definitions"`
+	Parameters    map[string]*Parameter `yaml:"parameters" json:"parameters"`
+	Extensions    []*Extension          `yaml:"x-extensions" json:"x-extensions"`
+	GlobalOptions GlobalOptions         `yaml:"x-global-options" json:"x-global-options"`
 }
 
 // Extension is used to define Protocol Buffer extensions from
@@ -125,7 +125,7 @@ type SchemaType []string
 
 // Schema represent Model properties in an OpenAPI spec.
 type Schema struct {
-	isNil   bool
+	isNil bool
 
 	// if this schema refers to a definition found elsewhere, this value
 	// is used. Note that if present, this takes precedence over other values
@@ -153,4 +153,6 @@ type Schema struct {
 	Pattern   string `yaml:"pattern,omitempty" json:"pattern,omitempty"`
 	MaxLength int    `yaml:"maxLength,omitempty" json:"max_length,omitempty"`
 	MinLength int    `yaml:"minLength,omitempty" json:"min_length,omitempty"`
+	Maximum   int    `yaml:"maximum,omitempty" json:"maximum,omitempty"`
+	Minimum   int    `yaml:"minimum,omitempty" json:"minumum,omitempty"`
 }


### PR DESCRIPTION
Same as buddy @chrusty did within https://github.com/NYTimes/openapi2proto/pull/44 but with max/min on top.

Sample:
```yaml
definitions:
  LatLong:
    type: object
    description: Specifies a geographic location in terms of its Latitude and Longitude
    required:
      - latitude
    properties:
      latitude:
        type: number
        format: double
        description: 'The latitude in degrees. It must be in the range [-90.0, +90.0]'
        minimum: -90
        maximum: 90
```