### PR TITLE
Change minLength/maxLength to camel so its picked up by the marshaler

### DIFF
--- a/openapi/interface.go
+++ b/openapi/interface.go
@@ -151,8 +151,8 @@ type Schema struct {
 
 	// validation (regex pattern, max/min length)
 	Pattern   string `yaml:"pattern,omitempty" json:"pattern,omitempty"`
-	MaxLength int    `yaml:"maxLength,omitempty" json:"max_length,omitempty"`
-	MinLength int    `yaml:"minLength,omitempty" json:"min_length,omitempty"`
+	MaxLength int    `yaml:"maxLength,omitempty" json:"maxLength,omitempty"`
+	MinLength int    `yaml:"minLength,omitempty" json:"minLength,omitempty"`
 	Maximum   int    `yaml:"maximum,omitempty" json:"maximum,omitempty"`
 	Minimum   int    `yaml:"minimum,omitempty" json:"minimum,omitempty"`
 }


### PR DESCRIPTION
minLength and maxLength are dropped when the re-encoding happens when unmarshalling to `Spec`  in `LoadFile`