### PR TITLE
Support single allOf element

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -587,6 +587,21 @@ func (c *compileCtx) compileSchema(name string, s *openapi.Schema) (protobuf.Typ
 		}
 		return m, nil
 	}
+
+	if len(s.AllOf) > 0 {
+		if len(s.AllOf) > 1 {
+			return nil, errors.New("allOf with multiple values is not supported")
+		}
+
+		// If there is only a single argument in allOf, then it's probably just for adding description, so just take the
+		// current field
+		m, err := c.compileSchema(name, s.AllOf[0])
+		if err != nil {
+			return nil, errors.Wrap(err, `failed to resolve allOf`)
+		}
+		return m, nil
+	}
+
 	rawName := name
 	name = camelCase(name)
 	// could be a builtin... try as-is once, then the camel cased

--- a/fixtures/refs.json
+++ b/fixtures/refs.json
@@ -55,6 +55,14 @@
             }
           },
           "x-proto-tag": 14
+        },
+        "test_allof_object_with_ref": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/TestModel3"
+            }
+          ],
+          "description": "AllOf object"
         }
       }
     },
@@ -72,6 +80,10 @@
           "x-proto-tag": 16
         }
       }
+    },
+    "TestModel3": {
+      "type": "string",
+      "description": "Test string"
     }
   }
 }

--- a/fixtures/refs.proto
+++ b/fixtures/refs.proto
@@ -19,6 +19,8 @@ message TestModel {
         int32 id = 1;
     }
 
+    // AllOf object
+    string test_allof_object_with_ref = 1;
     map<string, TestModel> test_map_object = 11;
     map<string, string> test_map_scalar = 12;
     map<string, TestMapArrayList> test_map_array = 13;

--- a/fixtures/refs.yaml
+++ b/fixtures/refs.yaml
@@ -39,6 +39,12 @@ definitions:
               id:
                 type: integer
         x-proto-tag: 15
+
+      test_allof_object_with_ref:
+          allOf:
+           - $ref: "#/definitions/TestModel3"
+          description: AllOf object
+
   TestModel2:
     type: object
     properties:
@@ -49,3 +55,6 @@ definitions:
           items:
             $ref: '#/definitions/TestModel'
         x-proto-tag: 16
+
+  TestModel3:
+    type: string

--- a/openapi/interface.go
+++ b/openapi/interface.go
@@ -147,6 +147,7 @@ type Schema struct {
 	Required             []string           `yaml:"required" json:"required"`
 	Properties           map[string]*Schema `yaml:"properties" json:"properties"`
 	AdditionalProperties *Schema            `yaml:"additionalProperties" json:"additionalProperties"`
+	AllOf                []*Schema          `yaml:"allOf" json:"allOf"`
 
 	// is an array
 	Items *Schema `yaml:"items" json:"items"`


### PR DESCRIPTION
In order to use $ref in a field, but still change the description -
need to support 'allOf', at least with a single field. Since it's just
a workaround to add description, in the proto implementation we can
just take the inner schema as-is