### PR TITLE
Don't prefix enums unless namespace-enums is true

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -489,15 +489,10 @@ func (c *compileCtx) getTypeFromReference(ref string) (protobuf.Type, error) {
 }
 
 func (c *compileCtx) compileEnum(name string, elements []string) (*protobuf.Enum, error) {
-	var prefix bool
-	if c.parent() != c.pkg || c.prefixEnums {
-		prefix = true
-	}
-
 	e := protobuf.NewEnum(camelCase(name))
 	for _, enum := range elements {
 		ename := enum
-		if prefix || looksLikeInteger(ename) {
+		if c.prefixEnums || looksLikeInteger(ename) {
 			ename = name + "_" + ename
 		}
 		ename = normalizeEnumName(ename)


### PR DESCRIPTION
The -namespace-enums command-line flag doesn't seem to be working because of this. (I've tried it true/false with no effect either way - it always adds prefixes. I can provide a repro if needed.)